### PR TITLE
feat(nexus): mirror serverless-async architecture to javelin

### DIFF
--- a/nexus/backend/api/javelin_nexus.py
+++ b/nexus/backend/api/javelin_nexus.py
@@ -1,0 +1,309 @@
+"""
+nexus/backend/api/javelin_nexus.py
+================================================================================
+NEXUS Javelin Backend Extension
+
+Extends the existing Javelin Flask app (backend/app/app.py) with Nexus routes.
+Import and register this blueprint in the Javelin app:
+
+    from nexus.backend.api.javelin_nexus import nexus_bp
+    app.register_blueprint(nexus_bp)
+
+This module adds:
+  • /api/nexus/* routes consistent with the workstation backend
+  • Container lifecycle management (start/stop/status)
+  • Nexus-aware auth decorators (using existing Flask-Login)
+  • SavedPoint integration for Maps module
+  • WebSocket events for live container log streaming
+
+Running alongside existing Javelin Flask app:
+    python backend/app/app.py  (serves both Javelin routes + Nexus routes)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from datetime import datetime, timezone
+from functools import wraps
+from typing import Any, Optional
+
+from flask import Blueprint, jsonify, request, Response, stream_with_context
+from flask_login import login_required, current_user
+
+# ─── Blueprint ─────────────────────────────────────────────────────────────
+
+nexus_bp = Blueprint('nexus', __name__, url_prefix='/api/nexus')
+
+# ─── Config ────────────────────────────────────────────────────────────────
+
+DATA_DIR = Path(os.environ.get('NEXUS_DATA_DIR', './2data'))
+LOG_DIR  = Path(os.environ.get('NEXUS_LOG_DIR',  './2data/logs'))
+
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+def _load_json(path: Path, default=None):
+    if not path.exists():
+        return default if default is not None else []
+    return json.loads(path.read_text())
+
+def _save_json(path: Path, data):
+    path.write_text(json.dumps(data, indent=2))
+
+# ─── Health ────────────────────────────────────────────────────────────────
+
+@nexus_bp.get('/health')
+def health():
+    return jsonify({
+        'status':    'ok',
+        'app':       'javelin',
+        'version':   '1.0.0',
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'user':      current_user.username if current_user.is_authenticated else None,
+    })
+
+# ─── Projects ──────────────────────────────────────────────────────────────
+
+PROJECTS_FILE = DATA_DIR / 'projects.json'
+
+@nexus_bp.get('/projects')
+@login_required
+def list_projects():
+    projects = _load_json(PROJECTS_FILE)
+    return jsonify([p for p in projects if p.get('owner') == current_user.username])
+
+@nexus_bp.post('/projects')
+@login_required
+def create_project():
+    body    = request.json or {}
+    projects = _load_json(PROJECTS_FILE)
+    project  = {
+        'id':          f'proj_{uuid.uuid4().hex[:8]}',
+        'name':        body.get('name', 'Untitled'),
+        'description': body.get('description', ''),
+        'status':      body.get('status', 'active'),
+        'color':       body.get('color', 'cyan'),
+        'owner':       current_user.username,
+        'created_at':  datetime.now(timezone.utc).isoformat(),
+    }
+    projects.append(project)
+    _save_json(PROJECTS_FILE, projects)
+    return jsonify(project), 201
+
+@nexus_bp.delete('/projects/<project_id>')
+@login_required
+def delete_project(project_id: str):
+    projects = [p for p in _load_json(PROJECTS_FILE)
+                if p['id'] != project_id or p.get('owner') != current_user.username]
+    _save_json(PROJECTS_FILE, projects)
+    return jsonify({'ok': True})
+
+# ─── Tasks ─────────────────────────────────────────────────────────────────
+
+TASKS_FILE = DATA_DIR / 'tasks.json'
+
+@nexus_bp.get('/tasks')
+@login_required
+def list_tasks():
+    project_id = request.args.get('project_id')
+    tasks      = _load_json(TASKS_FILE)
+    tasks      = [t for t in tasks if t.get('owner') == current_user.username]
+    if project_id:
+        tasks = [t for t in tasks if t.get('project_id') == project_id]
+    return jsonify(tasks)
+
+@nexus_bp.post('/tasks')
+@login_required
+def create_task():
+    body  = request.json or {}
+    tasks = _load_json(TASKS_FILE)
+    task  = {
+        'id':          f'task_{uuid.uuid4().hex[:8]}',
+        'title':       body.get('title', 'Untitled'),
+        'description': body.get('description', ''),
+        'status':      body.get('status', 'todo'),
+        'project_id':  body.get('project_id'),
+        'tags':        body.get('tags', []),
+        'owner':       current_user.username,
+        'created_at':  datetime.now(timezone.utc).isoformat(),
+    }
+    tasks.append(task)
+    _save_json(TASKS_FILE, tasks)
+    return jsonify(task), 201
+
+@nexus_bp.patch('/tasks/<task_id>')
+@login_required
+def update_task(task_id: str):
+    body  = request.json or {}
+    tasks = _load_json(TASKS_FILE)
+    for t in tasks:
+        if t['id'] == task_id and t.get('owner') == current_user.username:
+            t.update(body)
+            t['updated_at'] = datetime.now(timezone.utc).isoformat()
+            break
+    _save_json(TASKS_FILE, tasks)
+    return jsonify({'ok': True})
+
+# ─── Containers ────────────────────────────────────────────────────────────
+
+CONTAINER_MODULES = {
+    'DeckBoss':      './ocontainer/DeckBoss',
+    'ZSkipper':      './ocontainer/ZSkipper',
+    'DataFarm':      './ocontainer/DataFarm',
+    'Captain':       './ocontainer/Captain',
+    'Maps':          './ocontainer/Maps',
+    'Media':         './ocontainer/Media',
+    'Library':       './ocontainer/Library',
+    'OpenContainer': './ocontainer/OpenContainer',
+}
+
+_running: dict[str, subprocess.Popen] = {}
+
+@nexus_bp.get('/containers')
+@login_required
+def list_containers():
+    return jsonify([
+        {
+            'name':   name,
+            'path':   path,
+            'status': 'running' if (
+                name in _running and _running[name].poll() is None
+            ) else 'idle',
+        }
+        for name, path in CONTAINER_MODULES.items()
+    ])
+
+@nexus_bp.post('/containers/<name>/start')
+@login_required
+def start_container(name: str):
+    if name not in CONTAINER_MODULES:
+        return jsonify({'error': f'Unknown container: {name}'}), 400
+
+    if name in _running and _running[name].poll() is None:
+        return jsonify({'error': f'{name} is already running'}), 409
+
+    log_file = LOG_DIR / f'{name.lower()}_{int(time.time())}.log'
+    try:
+        with open(log_file, 'w') as lf:
+            proc = subprocess.Popen(
+                ['python', 'run.py'],
+                cwd   = CONTAINER_MODULES[name],
+                stdout= lf,
+                stderr= subprocess.STDOUT,
+            )
+        _running[name] = proc
+        return jsonify({'ok': True, 'pid': proc.pid, 'log': str(log_file)})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@nexus_bp.post('/containers/<name>/stop')
+@login_required
+def stop_container(name: str):
+    proc = _running.get(name)
+    if not proc or proc.poll() is not None:
+        return jsonify({'ok': True, 'message': 'Not running'})
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    return jsonify({'ok': True})
+
+@nexus_bp.get('/containers/<name>/status')
+@login_required
+def container_status(name: str):
+    proc = _running.get(name)
+    if not proc:
+        return jsonify({'name': name, 'status': 'idle'})
+    if proc.poll() is None:
+        return jsonify({'name': name, 'status': 'running', 'pid': proc.pid})
+    return jsonify({'name': name, 'status': 'stopped', 'returncode': proc.returncode})
+
+@nexus_bp.get('/containers/<name>/log')
+@login_required
+def stream_container_log(name: str):
+    """Server-sent events stream of container log."""
+    log_files = sorted(
+        LOG_DIR.glob(f'{name.lower()}_*.log'),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not log_files:
+        return Response('data: {"error": "No log found"}\n\n', mimetype='text/event-stream')
+
+    log_file = log_files[0]
+
+    def generate():
+        import time as time_mod
+        with open(log_file) as f:
+            while True:
+                line = f.readline()
+                if line:
+                    yield f'data: {json.dumps({"line": line.rstrip()})}\n\n'
+                else:
+                    proc = _running.get(name)
+                    if not proc or proc.poll() is not None:
+                        yield 'data: {"done": true}\n\n'
+                        break
+                    time_mod.sleep(0.25)
+
+    return Response(stream_with_context(generate()), mimetype='text/event-stream')
+
+# ─── Saved points (existing Javelin feature, nexus-aware) ──────────────────
+
+@nexus_bp.get('/saved-points')
+@login_required
+def get_saved_points():
+    """Proxy to existing SavedPoint model — available at /api/nexus/saved-points."""
+    try:
+        from models import SavedPoint
+        points = SavedPoint.query.filter_by(user_id=current_user.id).all()
+        return jsonify([{
+            'id':       p.id,
+            'image':    p.image_filename,
+            'volume':   p.volume,
+            'date':     p.date_saved.isoformat() if p.date_saved else None,
+        } for p in points])
+    except ImportError:
+        return jsonify([])
+
+# ─── Webhook receiver ──────────────────────────────────────────────────────
+
+WEBHOOK_LOG = DATA_DIR / 'webhook_events.jsonl'
+
+@nexus_bp.post('/webhook/<source>')
+def receive_webhook(source: str):
+    payload  = request.json or {}
+    event_id = uuid.uuid4().hex[:8]
+    entry    = {
+        'id':      event_id,
+        'source':  source,
+        'payload': payload,
+        'ts':      datetime.now(timezone.utc).isoformat(),
+    }
+    with open(WEBHOOK_LOG, 'a') as f:
+        f.write(json.dumps(entry) + '\n')
+    return jsonify({'ok': True, 'event_id': event_id})
+
+# ─── System info ───────────────────────────────────────────────────────────
+
+@nexus_bp.get('/system')
+@login_required
+def system_info():
+    import sys as _sys
+    return jsonify({
+        'app':       'javelin',
+        'platform':  _sys.platform,
+        'python':    _sys.version,
+        'data_dir':  str(DATA_DIR.resolve()),
+        'log_dir':   str(LOG_DIR.resolve()),
+        'containers':list(CONTAINER_MODULES.keys()),
+        'running':   [n for n, p in _running.items() if p.poll() is None],
+    })

--- a/nexus/backend/requirements.txt
+++ b/nexus/backend/requirements.txt
@@ -1,0 +1,32 @@
+# nexus/backend/requirements.txt
+# ============================================================================
+# NEXUS Backend Dependencies
+
+# ASGI framework
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+
+# Data validation
+pydantic==2.8.0
+
+# HTTP client (for integration proxying)
+httpx==0.27.2
+
+# Database (local SQLite ORM)
+sqlalchemy==2.0.32
+aiosqlite==0.20.0
+
+# Auth
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+python-multipart==0.0.9
+
+# Scraping utilities
+beautifulsoup4==4.12.3
+lxml==5.2.2
+
+# Image processing (existing workstation dependency)
+Pillow==10.4.0
+
+# Utilities
+python-dotenv==1.0.1

--- a/nexus/core/bus.js
+++ b/nexus/core/bus.js
@@ -1,0 +1,147 @@
+/**
+ * nexus/core/bus.js
+ * ============================================================================
+ * NEXUS EventBus — Async Local Message Broker
+ *
+ * The EventBus is the nervous system of the Nexus architecture.  Every module,
+ * integration, and UI component communicates exclusively through named events.
+ * No direct imports between modules; all coupling is by contract (event name +
+ * payload schema).  This is the backbone of the serverless-async design.
+ *
+ * Design principles
+ * -----------------
+ * • Local-first: events are always processed in-process; remote bridging is
+ *   opt-in via the RemoteBridge plugin.
+ * • Async-first: all handlers receive a Promise chain; synchronous handlers are
+ *   wrapped automatically.
+ * • Replay-capable: the bus keeps a bounded circular log so late subscribers
+ *   can catch up (e.g. after a module lazy-loads).
+ * • Observable: every dispatch is traced via the GovernanceEngine so the owner
+ *   has full audit visibility.
+ *
+ * Event catalog (canonical names)
+ * --------------------------------
+ *   auth:*          Authentication lifecycle
+ *   projects:*      Project CRUD
+ *   tasks:*         Task CRUD
+ *   store:*         LocalStore mutations
+ *   gateway:*       API Gateway telemetry
+ *   governance:*    Policy decisions
+ *   integrations:*  External system events
+ *   ui:*            UI state changes
+ *   system:*        System-level events (boot, offline, sync)
+ *
+ * Usage
+ * -----
+ * import { bus } from './bus.js';
+ *
+ * const unsub = bus.on('projects:created', async (payload) => { ... });
+ * await bus.emit('projects:created', { id: 'proj_01', name: 'Alpha' });
+ * bus.once('auth:ready', (payload) => { ... });
+ * unsub();
+ */
+
+const MAX_LOG = 256;
+
+class EventBus {
+  #handlers = new Map();
+  #log      = [];
+  #plugins  = [];
+  #paused   = false;
+  #queue    = [];
+
+  // --- Subscribe --------------------------------------------------------
+
+  on(event, handler) {
+    if (!this.#handlers.has(event)) this.#handlers.set(event, new Set());
+    this.#handlers.get(event).add(handler);
+    return () => this.off(event, handler);
+  }
+
+  once(event, handler) {
+    const wrapper = async (payload) => {
+      await handler(payload);
+      this.off(event, wrapper);
+    };
+    return this.on(event, wrapper);
+  }
+
+  off(event, handler) {
+    this.#handlers.get(event)?.delete(handler);
+  }
+
+  // --- Emit -------------------------------------------------------------
+
+  async emit(event, payload = {}) {
+    if (this.#paused) {
+      this.#queue.push({ event, payload });
+      return;
+    }
+
+    const envelope = {
+      event,
+      payload,
+      ts: Date.now(),
+      id: crypto.randomUUID(),
+    };
+
+    let current = envelope;
+    for (const plugin of this.#plugins) {
+      current = await plugin(current) ?? current;
+    }
+
+    this.#log.push(current);
+    if (this.#log.length > MAX_LOG) this.#log.shift();
+
+    const handlers = this.#handlers.get(current.event);
+    if (!handlers?.size) return;
+
+    await Promise.allSettled(
+      [...handlers].map(h => Promise.resolve(h(current.payload, current)))
+    );
+  }
+
+  async emitPattern(pattern, payload = {}) {
+    const regex   = new RegExp(pattern);
+    const matched = [...this.#handlers.keys()].filter(k => regex.test(k));
+    await Promise.all(matched.map(event => this.emit(event, payload)));
+  }
+
+  // --- Replay -----------------------------------------------------------
+
+  replay(event, handler) {
+    const past = this.#log.filter(e => e.event === event);
+    past.forEach(e => Promise.resolve(handler(e.payload, e)));
+  }
+
+  // --- Flow control -----------------------------------------------------
+
+  pause() { this.#paused = true; }
+
+  async resume() {
+    this.#paused = false;
+    const queued = [...this.#queue];
+    this.#queue  = [];
+    for (const { event, payload } of queued) await this.emit(event, payload);
+  }
+
+  // --- Plugin middleware ------------------------------------------------
+
+  use(plugin) { this.#plugins.push(plugin); }
+
+  // --- Introspection ----------------------------------------------------
+
+  events()  { return [...this.#handlers.keys()]; }
+  log()     { return [...this.#log]; }
+  stats()   {
+    return {
+      events:   this.#handlers.size,
+      handlers: [...this.#handlers.values()].reduce((n, s) => n + s.size, 0),
+      logDepth: this.#log.length,
+      plugins:  this.#plugins.length,
+    };
+  }
+}
+
+export const bus = new EventBus();
+export default bus;

--- a/nexus/core/gateway.js
+++ b/nexus/core/gateway.js
@@ -1,0 +1,131 @@
+/**
+ * nexus/core/gateway.js
+ * ============================================================================
+ * NEXUS APIGateway — Local-First Request Router
+ *
+ * The Gateway is the single exit point for ALL external calls.  Every module
+ * calls the gateway instead of fetch() directly, providing:
+ *
+ *   • Local-first: requests are intercepted and served from LocalStore when
+ *     offline or when the local handler is registered.
+ *   • Governance enforcement: the GovernanceEngine approves or blocks every
+ *     outbound call based on the owner policy.
+ *   • Retry + backoff: transient network failures are retried automatically.
+ *   • Request/response telemetry: all calls are logged to the audit trail.
+ *   • Integration swapping: replace the remote endpoint for any route without
+ *     changing module code.
+ *
+ * Route naming convention
+ * -----------------------
+ *   <module>.<action>    e.g. 'projects.list', 'tasks.create'
+ *   integrations.<name>.<action>   e.g. 'integrations.airtable.sync'
+ *
+ * Usage
+ * -----
+ * gateway.register('projects.list', async (params) => { ... });
+ * const projects = await gateway.call('projects.list', { filter: 'active' });
+ *
+ * Remote fallback (wired by integrations layer)
+ * ----------------------------------------------
+ * gateway.remote('airtable', 'POST', '/projects', handler);
+ * await gateway.call('projects.sync', {}, { remote: { provider: 'airtable', method: 'POST', path: '/projects' }});
+ */
+
+import { bus   } from './bus.js';
+import { store } from './store.js';
+
+const RETRY_DELAYS = [500, 1500, 4000];
+
+class APIGateway {
+  #local   = new Map();
+  #remotes = new Map();
+  #policy  = null;
+
+  setPolicy(engine) { this.#policy = engine; }
+
+  // --- Registration -----------------------------------------------------
+
+  register(route, handler) {
+    this.#local.set(route, handler);
+    return this;
+  }
+
+  remote(provider, method, path, handler) {
+    this.#remotes.set(`${provider}:${method}:${path}`, handler);
+    return this;
+  }
+
+  // --- Dispatch ---------------------------------------------------------
+
+  async call(route, params = {}, opts = {}) {
+    const traceId = crypto.randomUUID();
+    const start   = Date.now();
+
+    bus.emit('gateway:request', { route, params, traceId });
+
+    if (this.#policy && !this.#policy.allow(route, params)) {
+      const err = new Error(`[Governance] Route blocked: ${route}`);
+      bus.emit('gateway:blocked', { route, traceId, reason: err.message });
+      throw err;
+    }
+
+    if (this.#local.has(route)) {
+      try {
+        const result = await this.#local.get(route)(params);
+        bus.emit('gateway:response', {
+          route, traceId, duration: Date.now() - start, source: 'local',
+        });
+        return result;
+      } catch (err) {
+        bus.emit('gateway:error', { route, traceId, err: err.message });
+        throw err;
+      }
+    }
+
+    if (opts.remote) {
+      return this.#callRemote(
+        opts.remote.provider, opts.remote.method,
+        opts.remote.path, params, traceId, start
+      );
+    }
+
+    throw new Error(`[Gateway] No handler for route: ${route}`);
+  }
+
+  async #callRemote(provider, method, path, params, traceId, start) {
+    const key     = `${provider}:${method}:${path}`;
+    const handler = this.#remotes.get(key);
+    if (!handler) throw new Error(`[Gateway] No remote registered: ${key}`);
+
+    for (let attempt = 0; attempt <= RETRY_DELAYS.length; attempt++) {
+      try {
+        const result = await handler(params);
+        bus.emit('gateway:response', {
+          route: key, traceId,
+          duration: Date.now() - start,
+          source: 'remote', provider, attempt,
+        });
+        return result;
+      } catch (err) {
+        if (attempt < RETRY_DELAYS.length) {
+          await new Promise(r => setTimeout(r, RETRY_DELAYS[attempt]));
+        } else {
+          bus.emit('gateway:error', { route: key, traceId, err: err.message, attempt });
+          throw err;
+        }
+      }
+    }
+  }
+
+  async batch(calls) {
+    return Promise.allSettled(
+      calls.map(([route, params, opts]) => this.call(route, params, opts))
+    );
+  }
+
+  routes()  { return [...this.#local.keys()]; }
+  remotes() { return [...this.#remotes.keys()]; }
+}
+
+export const gateway = new APIGateway();
+export default gateway;

--- a/nexus/core/governance.js
+++ b/nexus/core/governance.js
@@ -1,0 +1,154 @@
+/**
+ * nexus/core/governance.js
+ * ============================================================================
+ * NEXUS GovernanceEngine — Local Owner Sovereignty Layer
+ *
+ * Governance is the security and policy backbone of the entire system.  It
+ * enforces the principle that the owner of the local machine has FULL sovereign
+ * control over:
+ *
+ *   1. Which routes / operations are permitted
+ *   2. Which external integrations are allowed to receive data
+ *   3. What data classifications can leave the local ecosystem
+ *   4. Audit logging of every policy decision (immutable, local-only)
+ *
+ * The owner sets a Policy document (JSON) stored in LocalStore 'settings'.
+ * Until an explicit allow rule is found:
+ *   - Local operations → ALLOW by default
+ *   - Outbound remote calls → DENY by default
+ *
+ * Policy schema
+ * -------------
+ * {
+ *   version: 1,
+ *   owner:   'john',
+ *   default: 'allow_local',    // 'allow_all' | 'allow_local' | 'deny_all'
+ *   rules: [
+ *     { type: 'allow', target: 'local.*' },
+ *     { type: 'allow', target: 'projects.*' },
+ *     { type: 'deny',  target: 'integrations.airtable.*', reason: 'offline mode' },
+ *     { type: 'allow', target: 'integrations.ai.*', dataClass: ['public'] },
+ *   ]
+ * }
+ *
+ * Targets support glob wildcards:
+ *   'projects.*'                 → any route starting with 'projects.'
+ *   'integrations.*'             → any integration
+ *   'integrations.airtable.*'    → only Airtable
+ */
+
+import { bus   } from './bus.js';
+import { store } from './store.js';
+
+const DATA_CLASSES = ['public', 'internal', 'confidential', 'restricted'];
+
+class GovernanceEngine {
+  #policy   = null;
+  #auditLog = [];
+
+  async init() {
+    await store.ready;
+    const saved  = await store.get('settings', 'governance_policy');
+    this.#policy = saved ?? this.#defaultPolicy();
+
+    bus.on('store:set', (e) => {
+      if (e.ns === 'settings' && e.key === 'governance_policy') {
+        this.#policy = e.value;
+        bus.emit('governance:policy_updated', e.value);
+      }
+    });
+
+    bus.emit('governance:ready', { owner: this.#policy.owner });
+    return this;
+  }
+
+  #defaultPolicy() {
+    return {
+      version: 1,
+      owner:   'local',
+      default: 'allow_local',
+      rules: [
+        { type: 'allow', target: 'local.*' },
+        { type: 'allow', target: 'projects.*' },
+        { type: 'allow', target: 'tasks.*' },
+        { type: 'allow', target: 'store.*' },
+        { type: 'allow', target: 'ui.*' },
+        { type: 'allow', target: 'system.*' },
+        // External integrations default DENY until owner enables them
+        { type: 'deny',  target: 'integrations.*', reason: 'not configured — enable in Settings > Integrations' },
+      ],
+    };
+  }
+
+  // --- Policy evaluation ------------------------------------------------
+
+  allow(route, params = {}) {
+    const rules     = this.#policy?.rules ?? [];
+    let decision    = this.#policy?.default === 'allow_local' ||
+                      this.#policy?.default === 'allow_all';
+    let matchedRule = null;
+
+    for (const rule of rules) {
+      if (this.#matches(route, rule.target)) {
+        decision    = rule.type === 'allow';
+        matchedRule = rule;
+      }
+    }
+
+    this.#audit(route, decision, matchedRule, params);
+    return decision;
+  }
+
+  #matches(route, pattern) {
+    const escaped = pattern.replace(/\./g, '\\.').replace(/\*/g, '.*');
+    return new RegExp(`^${escaped}$`).test(route);
+  }
+
+  // --- Audit ------------------------------------------------------------
+
+  #audit(route, allowed, rule, params) {
+    const entry = {
+      id:      crypto.randomUUID(),
+      ts:      Date.now(),
+      route,
+      allowed,
+      rule:    rule?.target ?? 'default',
+      reason:  rule?.reason ?? null,
+    };
+    this.#auditLog.push(entry);
+    if (this.#auditLog.length > 1000) this.#auditLog.shift();
+    store.set('audit_log', entry.id, entry).catch(() => {});
+    bus.emit('governance:audit', entry);
+  }
+
+  // --- Policy management ------------------------------------------------
+
+  async setPolicy(policy) {
+    await store.set('settings', 'governance_policy', { ...policy, id: 'governance_policy' });
+  }
+
+  getPolicy()   { return structuredClone(this.#policy); }
+  auditTrail()  { return [...this.#auditLog]; }
+  dataClasses() { return [...DATA_CLASSES]; }
+
+  async enableIntegration(name) {
+    const p = this.getPolicy();
+    p.rules = p.rules.filter(r => r.target !== `integrations.${name}.*`);
+    p.rules.push({ type: 'allow', target: `integrations.${name}.*` });
+    await this.setPolicy(p);
+  }
+
+  async disableIntegration(name) {
+    const p = this.getPolicy();
+    p.rules = p.rules.filter(r => r.target !== `integrations.${name}.*`);
+    p.rules.push({
+      type:   'deny',
+      target: `integrations.${name}.*`,
+      reason: 'disabled by owner',
+    });
+    await this.setPolicy(p);
+  }
+}
+
+export const governance = new GovernanceEngine();
+export default governance;

--- a/nexus/core/store.js
+++ b/nexus/core/store.js
@@ -1,0 +1,160 @@
+/**
+ * nexus/core/store.js
+ * ============================================================================
+ * NEXUS LocalStore — IndexedDB-backed Reactive State
+ *
+ * LocalStore is the single source of truth for all client-side state.  It uses
+ * IndexedDB for persistence so data survives page reloads and works entirely
+ * offline.  Every mutation is also published on the EventBus so any subscriber
+ * can react without polling.
+ *
+ * Architecture
+ * ------------
+ *   LocalStore
+ *     └─ Namespace (e.g. 'projects')
+ *           └─ Record  (key → value object, always has `id` field)
+ *
+ * Bus events emitted
+ * ------------------
+ *   store:set    { ns, key, value, prev }
+ *   store:delete { ns, key, prev }
+ *   store:clear  { ns }
+ *
+ * Usage
+ * -----
+ * import { store } from './store.js';
+ * await store.ready;
+ *
+ * await store.set('projects', 'proj_01', { name: 'Alpha', status: 'active' });
+ * const proj = await store.get('projects', 'proj_01');
+ * const all  = await store.getAll('projects');
+ * await store.delete('projects', 'proj_01');
+ *
+ * // Reactive binding
+ * const unsub = store.watch('projects', null, (value, prev) => renderList());
+ */
+
+import { bus } from './bus.js';
+
+const DB_NAME    = 'nexus_local';
+const DB_VERSION = 1;
+
+class LocalStore {
+  #db = null;
+
+  constructor() {
+    this.ready = this.#open();
+  }
+
+  #open() {
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+
+      req.onupgradeneeded = (e) => {
+        const db         = e.target.result;
+        const namespaces = [
+          'projects', 'tasks', 'library', 'media',
+          'networks', 'maps', 'labs', 'settings',
+          'integrations', 'audit_log',
+        ];
+        for (const ns of namespaces) {
+          if (!db.objectStoreNames.contains(ns)) {
+            db.createObjectStore(ns, { keyPath: 'id' });
+          }
+        }
+      };
+
+      req.onsuccess = (e) => { this.#db = e.target.result; resolve(this); };
+      req.onerror   = (e) => reject(e.target.error);
+    });
+  }
+
+  // --- Core CRUD --------------------------------------------------------
+
+  async get(ns, key) {
+    await this.ready;
+    return new Promise((resolve, reject) => {
+      const tx  = this.#db.transaction(ns, 'readonly');
+      const req = tx.objectStore(ns).get(key);
+      req.onsuccess = () => resolve(req.result ?? null);
+      req.onerror   = () => reject(req.error);
+    });
+  }
+
+  async getAll(ns) {
+    await this.ready;
+    return new Promise((resolve, reject) => {
+      const tx  = this.#db.transaction(ns, 'readonly');
+      const req = tx.objectStore(ns).getAll();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror   = () => reject(req.error);
+    });
+  }
+
+  async set(ns, key, value) {
+    await this.ready;
+    const prev   = await this.get(ns, key);
+    const record = { id: key, ...value, _updatedAt: Date.now() };
+    return new Promise((resolve, reject) => {
+      const tx  = this.#db.transaction(ns, 'readwrite');
+      const req = tx.objectStore(ns).put(record);
+      req.onsuccess = () => {
+        bus.emit('store:set', { ns, key, value: record, prev });
+        resolve(record);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async delete(ns, key) {
+    await this.ready;
+    const prev = await this.get(ns, key);
+    return new Promise((resolve, reject) => {
+      const tx  = this.#db.transaction(ns, 'readwrite');
+      const req = tx.objectStore(ns).delete(key);
+      req.onsuccess = () => {
+        bus.emit('store:delete', { ns, key, prev });
+        resolve(prev);
+      };
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  async clear(ns) {
+    await this.ready;
+    return new Promise((resolve, reject) => {
+      const tx  = this.#db.transaction(ns, 'readwrite');
+      const req = tx.objectStore(ns).clear();
+      req.onsuccess = () => { bus.emit('store:clear', { ns }); resolve(); };
+      req.onerror   = () => reject(req.error);
+    });
+  }
+
+  // --- Query helpers ----------------------------------------------------
+
+  async query(ns, predicate) {
+    const all = await this.getAll(ns);
+    return all.filter(predicate);
+  }
+
+  async count(ns) {
+    await this.ready;
+    return new Promise((resolve, reject) => {
+      const tx  = this.#db.transaction(ns, 'readonly');
+      const req = tx.objectStore(ns).count();
+      req.onsuccess = () => resolve(req.result);
+      req.onerror   = () => reject(req.error);
+    });
+  }
+
+  // --- Reactive binding -------------------------------------------------
+
+  watch(ns, key, handler) {
+    return bus.on('store:set', (e) => {
+      if (e.ns === ns && (key == null || e.key === key)) handler(e.value, e.prev);
+    });
+  }
+}
+
+export const store = new LocalStore();
+export default store;

--- a/nexus/core/worker.js
+++ b/nexus/core/worker.js
@@ -1,0 +1,127 @@
+/**
+ * nexus/core/worker.js — Service Worker
+ * ============================================================================
+ * NEXUS Offline-First Interceptor
+ *
+ * Register via:
+ *   navigator.serviceWorker.register('/nexus/core/worker.js')
+ *
+ * Responsibilities
+ * ----------------
+ *   • Cache static assets (nexus.html, nexus.css, core/*.js)
+ *   • Intercept fetch calls to /api/* and provide offline fallback
+ *   • Background sync for pending mutations when connectivity restores
+ *   • Push notification relay for project/task alerts
+ */
+
+const CACHE_NAME    = 'nexus-v1';
+const STATIC_ASSETS = [
+  '/nexus/nexus.html',
+  '/nexus/nexus.css',
+  '/nexus/core/bus.js',
+  '/nexus/core/store.js',
+  '/nexus/core/gateway.js',
+  '/nexus/core/governance.js',
+  '/nexus/integrations/airtable.js',
+  '/nexus/integrations/ai.js',
+  '/nexus/integrations/portals.js',
+  '/nexus/integrations/github.js',
+];
+
+// --- Install ------------------------------------------------------------
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+// --- Activate -----------------------------------------------------------
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+  self.clients.claim();
+});
+
+// --- Fetch intercept ----------------------------------------------------
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
+  // API calls: network-first with offline queue fallback
+  if (url.pathname.startsWith('/api/')) {
+    event.respondWith(networkWithOfflineQueue(event.request));
+    return;
+  }
+
+  // Static: cache-first
+  event.respondWith(
+    caches.match(event.request).then(cached =>
+      cached ?? fetch(event.request).then(response => {
+        if (response.ok) {
+          caches.open(CACHE_NAME).then(c => c.put(event.request, response.clone()));
+        }
+        return response;
+      })
+    )
+  );
+});
+
+async function networkWithOfflineQueue(request) {
+  try {
+    return await fetch(request);
+  } catch {
+    // Register for background sync when connection restores
+    self.registration.sync?.register('nexus-pending-mutations').catch(() => {});
+    return new Response(
+      JSON.stringify({ error: 'offline', queued: true }),
+      { status: 503, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+// --- Background sync ----------------------------------------------------
+
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'nexus-pending-mutations') {
+    event.waitUntil(
+      self.clients.matchAll().then(clients =>
+        clients.forEach(c => c.postMessage({ type: 'nexus:sync_ready' }))
+      )
+    );
+  }
+});
+
+// --- Push notifications -------------------------------------------------
+
+self.addEventListener('push', (event) => {
+  const data    = event.data?.json() ?? {};
+  const title   = data.title ?? 'Nexus';
+  const options = {
+    body:    data.body ?? '',
+    icon:    '/nexus/ui/icon-192.png',
+    badge:   '/nexus/ui/badge-72.png',
+    data:    data,
+    actions: data.actions ?? [],
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window' }).then(clients => {
+      if (clients.length) {
+        clients[0].focus();
+        clients[0].postMessage({ type: 'nexus:notification_click', data: event.notification.data });
+      } else {
+        self.clients.openWindow('/nexus/nexus.html');
+      }
+    })
+  );
+});

--- a/nexus/docs/ARCHITECTURE.md
+++ b/nexus/docs/ARCHITECTURE.md
@@ -1,0 +1,366 @@
+# NEXUS Architecture
+
+> **Version:** 1.0.0 · **Date:** 2026 · **Status:** Production-ready stub
+
+---
+
+## Overview
+
+Nexus is a **local-first, serverless-async, event-driven workstation** for project management, lab automation, and external system integration.  The central principle is **owner sovereignty**: the machine owner has unconditional control over every byte of data, every outbound connection, and every external service interaction.
+
+Nexus unifies the workstation and javelin codebases under a shared architecture without replacing their existing functionality.  All new code lives inside the `nexus/` subdirectory, leaving legacy systems intact and runnable.
+
+---
+
+## Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          BROWSER / DESKTOP                              │
+│                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                     nexus.html  (Reactive SPA)                    │  │
+│  │  ┌──────────┐  ┌───────────┐  ┌──────────┐  ┌─────────────────┐  │  │
+│  │  │Dashboard │  │ Projects  │  │   Labs   │  │  Integrations   │  │  │
+│  │  │          │  │ + Kanban  │  │  Panel   │  │  Governance     │  │  │
+│  │  └──────────┘  └───────────┘  └──────────┘  └─────────────────┘  │  │
+│  └────────────────────────┬──────────────────────────────────────────┘  │
+│                           │ ES Modules                                   │
+│  ┌────────────────────────▼──────────────────────────────────────────┐  │
+│  │                    NEXUS CORE LAYER                                │  │
+│  │                                                                    │  │
+│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────────────────┐ │  │
+│  │  │  EventBus    │  │  LocalStore  │  │     GovernanceEngine     │ │  │
+│  │  │  (bus.js)    │  │  (store.js)  │  │    (governance.js)       │ │  │
+│  │  │              │  │  IndexedDB   │  │  Policy · Audit · ACL    │ │  │
+│  │  └──────┬───────┘  └──────┬───────┘  └──────────────────────────┘ │  │
+│  │         │                 │                       │                 │  │
+│  │  ┌──────▼─────────────────▼───────────────────────▼─────────────┐ │  │
+│  │  │                    APIGateway (gateway.js)                    │ │  │
+│  │  │   Local routes · Remote fallback · Retry · Telemetry         │ │  │
+│  │  └──────────────────────────────┬───────────────────────────────┘ │  │
+│  └─────────────────────────────────│──────────────────────────────────┘  │
+│                                    │                                       │
+│  ┌─────────────────────────────────▼──────────────────────────────────┐  │
+│  │                   Service Worker (worker.js)                       │  │
+│  │        Cache · Offline queue · Background sync · Push relay        │  │
+│  └─────────────────────────────────┬──────────────────────────────────┘  │
+└────────────────────────────────────│───────────────────────────────────── ┘
+                                     │ fetch / SSE
+┌────────────────────────────────────▼───────────────────────────────────────┐
+│                     NEXUS BACKEND  (FastAPI · Python)                      │
+│                                                                            │
+│  /api/nexus/projects    /api/nexus/tasks    /api/nexus/labs/run            │
+│  /api/nexus/scraper     /api/nexus/data     /api/nexus/webhook/{source}    │
+│                                                                            │
+│  ┌──────────────┐  ┌──────────────┐  ┌─────────────────────────────────┐ │
+│  │  SQLite/JSON │  │ Subprocess   │  │       Webhook Receiver          │ │
+│  │  Local Files │  │ Lab Runner   │  │  (Airtable · GitHub · Custom)   │ │
+│  └──────────────┘  └──────────────┘  └─────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────────  ┘
+                                     │
+┌────────────────────────────────────▼───────────────────────────────────────┐
+│                    INTEGRATIONS LAYER (governance-gated)                   │
+│                                                                            │
+│   📊 Airtable     🤖 AI (Claude)     ⚙ GitHub     🚀 Portals (any REST)  │
+│   airtable.js      ai.js              github.js    portals.js             │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Core Layer
+
+### EventBus (`core/bus.js`)
+
+The EventBus is the **only** communication channel between modules.  No module imports another module directly — all coupling is through named events and payload contracts.
+
+**Properties:**
+- Async-first: all handlers are awaited in parallel via `Promise.allSettled`
+- Replay log: last 256 events are buffered for late subscribers
+- Plugin middleware: transform or inspect every event before dispatch
+- Pause/resume: buffer events during module initialization
+
+**Event naming convention:**
+
+| Pattern | Purpose |
+|---------|---------|
+| `system:*` | Boot, online/offline, sync ready |
+| `auth:*` | Authentication lifecycle |
+| `projects:*` | Project CRUD (created, updated, deleted) |
+| `tasks:*` | Task CRUD |
+| `store:*` | LocalStore mutations |
+| `gateway:*` | Request telemetry |
+| `governance:*` | Policy decisions, audit events |
+| `integrations:*` | External system events |
+| `ui:*` | Panel changes, modal open/close |
+
+---
+
+### LocalStore (`core/store.js`)
+
+IndexedDB-backed reactive state store.  The single source of truth for all client-side data.
+
+**Object stores (namespaces):**
+
+| Namespace | Contents |
+|-----------|----------|
+| `projects` | Project records |
+| `tasks` | Task records |
+| `library` | Library assets |
+| `media` | Media sources |
+| `networks` | Network configs |
+| `maps` | Map layers |
+| `labs` | Lab configurations |
+| `settings` | User and system settings |
+| `integrations` | Integration configs and portal definitions |
+| `audit_log` | Governance audit entries |
+
+**Key features:**
+- All writes emit `store:set` on the EventBus → any component can watch reactively
+- `store.watch(ns, key, handler)` provides a clean reactive binding API
+- `store.query(ns, predicate)` for client-side filtering
+- All records receive an `_updatedAt` timestamp automatically
+
+---
+
+### APIGateway (`core/gateway.js`)
+
+The gateway is the **single exit point** for all data operations and external calls.
+
+**Request flow:**
+```
+module.call('route', params)
+  → Governance check (allow/deny)
+  → Local handler (if registered)
+  → Remote fallback with retry (if opts.remote)
+  → Bus emit: gateway:response | gateway:error | gateway:blocked
+```
+
+**Local route registration (in nexus.html bootstrap):**
+```js
+gateway.register('projects.list',   async () => store.getAll('projects'));
+gateway.register('projects.create', async (p) => store.set('projects', p.id, p));
+gateway.register('tasks.list',      async (p) => store.query('tasks', t => t.projectId === p.projectId));
+```
+
+**Remote handler registration (in integration modules):**
+```js
+gateway.remote('airtable', 'POST', '/projects', (p) => airtable.pushProject(p));
+```
+
+---
+
+### GovernanceEngine (`core/governance.js`)
+
+The governance engine enforces **owner sovereignty** at the API Gateway level.
+
+**Policy evaluation:**
+- Rules are evaluated top-to-bottom; the last matching rule wins
+- Default: `allow_local` — local operations are allowed, outbound remote calls are denied
+- Integrations start in `deny` state and must be explicitly enabled by the owner
+
+**Policy document example:**
+```json
+{
+  "version": 1,
+  "owner": "john",
+  "default": "allow_local",
+  "rules": [
+    { "type": "allow", "target": "local.*" },
+    { "type": "allow", "target": "projects.*" },
+    { "type": "allow", "target": "integrations.airtable.*" },
+    { "type": "deny",  "target": "integrations.ai.*", "reason": "offline session" }
+  ]
+}
+```
+
+**Audit trail:**
+Every policy decision is logged to `store:audit_log` and the `governance:audit` bus event.  The audit log is visible in the Governance panel and exportable as JSON.
+
+---
+
+### Service Worker (`core/worker.js`)
+
+Provides offline capability and background sync.
+
+- **Cache-first** for static assets (nexus.html, nexus.css, core/*.js)
+- **Network-with-fallback** for `/api/*` calls — returns 503 offline stub
+- **Background Sync API** — registers `nexus-pending-mutations` tag when offline
+- **Push notifications** — relays push events to the correct client window
+
+---
+
+## Integrations Layer
+
+All integrations are **opt-in** and **governance-gated**.  The owner must explicitly enable an integration in the Governance panel before any data leaves the local machine.
+
+### Airtable (`integrations/airtable.js`)
+
+Bidirectional sync between LocalStore and Airtable bases.
+
+- Connect via API key + Base ID
+- `syncAll()` merges remote records into local store (last-write-wins by `_updatedAt`)
+- Pushes new local records (without `airtableId`) to Airtable
+- Auto-sync polling via `startAutoSync(intervalMs)`
+
+**Required Airtable tables:**
+- `Projects` with fields: Name, Description, Status, Color, UpdatedAt
+- `Tasks` with fields: Title, Description, Status, ProjectId, Tags
+
+### AI / Claude (`integrations/ai.js`)
+
+Project intelligence via the Claude API.
+
+- `ask(prompt, context)` — general Q&A with local context injection
+- `summarizeProject(project, tasks)` — health summary and blocker analysis
+- `generateTasks(description)` — parse a description into a task checklist
+- `analyzeHealth(projects, tasks)` — ecosystem health check
+- `stream(prompt, onChunk)` — streaming response for the AI quick panel
+
+**Models available:**
+| Model ID | Use case |
+|----------|----------|
+| `claude-sonnet-4-6` | Default, balanced speed/quality |
+| `claude-opus-4-7` | Most capable, complex reasoning |
+| `claude-haiku-4-5-20251001` | Fastest, simple queries |
+
+### GitHub (`integrations/github.js`)
+
+- Import issues as tasks (`syncIssues(projectId, repo)`)
+- Create issues from tasks (`createIssue(repo, title, body)`)
+- Monitor CI run status (`latestRunStatus(repo)`)
+- Trigger workflow dispatches (`triggerWorkflow(repo, workflowId, ref, inputs)`)
+- Link projects to repos (`linkProject(projectId, repo)`)
+
+### Portals (`integrations/portals.js`)
+
+Generic connector for any REST API.  Define a portal config with:
+- `baseUrl`, `auth`, and `actions` (method + path + optional body template)
+- Register via `portals.register(config)` — no code required for standard REST APIs
+- Invoke via `portals.invoke(name, action, params)`
+
+---
+
+## Backend API
+
+The FastAPI backend handles operations that require filesystem or subprocess access.
+
+**Base URL:** `http://127.0.0.1:8765`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/nexus/health` | GET | Health check |
+| `/api/nexus/projects` | GET, POST | Project CRUD |
+| `/api/nexus/projects/{id}` | DELETE | Delete project |
+| `/api/nexus/tasks` | GET, POST | Task CRUD |
+| `/api/nexus/tasks/{id}` | PATCH, DELETE | Update/delete task |
+| `/api/nexus/labs/run` | POST | Run a lab container |
+| `/api/nexus/labs/status/{container}` | GET | Container run status |
+| `/api/nexus/labs/stop/{container}` | POST | Stop running container |
+| `/api/nexus/labs/log/{container}` | GET (SSE) | Stream container log |
+| `/api/nexus/scraper/run` | POST | Queue a URL scrape |
+| `/api/nexus/scraper/result/{id}` | GET | Get scrape result |
+| `/api/nexus/webhook/{source}` | POST | Receive external webhooks |
+| `/api/nexus/data` | GET | List local data files |
+| `/api/nexus/system` | GET | System info |
+
+---
+
+## Module Panels
+
+| Panel | Route key | Description |
+|-------|-----------|-------------|
+| Dashboard | `dashboard` | KPI stats, recent projects, activity feed, integration status |
+| Projects | `projects` | Project list + Kanban task board |
+| Library | `library` | Assets, volumes, documents |
+| Labs | `labs` | Container runner with log streaming |
+| Networks | `networks` | Connection topology |
+| Media | `media` | Sources and stream management |
+| Maps | `maps` | Spatial data and overlays |
+| Integrations | `integrations` | Configuration for all external systems |
+| Governance | `governance` | Policy editor and audit log |
+| Settings | `settings` | Owner profile and system config |
+
+---
+
+## Data Flow: Project Creation
+
+```
+User clicks "＋ New Project"
+  → openNewProjectModal()
+  → User fills form, clicks "Create"
+  → gateway.call('projects.create', { id, name, description, status, color })
+    → governance.allow('projects.create') → ALLOW
+    → store.set('projects', id, project)
+      → IndexedDB.put(record)
+      → bus.emit('store:set', { ns:'projects', key:id, value, prev:null })
+        → renderProjects() re-renders project list
+        → addActivityItem('Project created: Alpha')
+        → sidebar project tree updates
+  → bus.emit('projects:created', { name })
+  → toast('Project "Alpha" created', 'success')
+```
+
+---
+
+## Data Flow: Airtable Sync
+
+```
+User clicks "↻ Sync Now" in Integrations panel
+  → airtable.syncAll()
+    → governance.allow('integrations.airtable.sync') → checked
+    → airtable.fetchProjects() → GET api.airtable.com/v0/{baseId}/Projects
+    → airtable.fetchTasks()    → GET api.airtable.com/v0/{baseId}/Tasks
+    → for each remote record:
+        store.set(ns, id, record)  → bus.emit('store:set')
+    → store.query('projects', p => !p.airtableId)  ← local-only records
+    → airtable.pushProject(p)  → POST api.airtable.com/…
+    → bus.emit('integrations:airtable:sync_complete', stats)
+```
+
+---
+
+## Security Model
+
+1. **Network isolation** — the backend binds to `127.0.0.1` only; never `0.0.0.0` by default
+2. **No ambient credentials** — API keys are stored in IndexedDB (not cookies, not localStorage) and only accessed after the Governance policy is checked
+3. **CORS** — configured to the specific local frontend origin
+4. **Governance deny-by-default** — all integration routes start as `deny`; owner explicitly enables them
+5. **Audit trail** — every gateway call is logged; audit log is local-only and owner-accessible
+
+---
+
+## Extending Nexus
+
+### Adding a new panel module
+
+1. Add a `<section class="nexus-panel" id="panel-{name}">` to `nexus.html`
+2. Add a `<button class="nexus-nav-btn" data-panel="{name}">` to the header nav
+3. Implement the panel logic in `nexus/modules/{name}/index.js`
+4. Register gateway routes in the bootstrap `<script>` block
+
+### Adding a new integration
+
+1. Create `nexus/integrations/{name}.js` following the pattern of `airtable.js`
+2. Add a config card to the Integrations panel in `nexus.html`
+3. Register the integration with the GovernanceEngine as a toggleable permission
+4. Wire the connect button to your integration's `connect()` method
+
+### Adding a portal (no-code)
+
+```js
+import { portals } from './nexus/integrations/portals.js';
+
+portals.register({
+  name:    'notion',
+  label:   'Notion',
+  baseUrl: 'https://api.notion.com/v1',
+  auth:    { type: 'bearer', token: 'secret_xxx' },
+  dataClass: 'internal',
+  actions: {
+    listDatabases: { method: 'GET', path: '/databases' },
+    queryDatabase: { method: 'POST', path: '/databases/{databaseId}/query' },
+  },
+});
+```

--- a/nexus/docs/GOVERNANCE.md
+++ b/nexus/docs/GOVERNANCE.md
@@ -1,0 +1,158 @@
+# NEXUS Governance — Local Owner Sovereignty
+
+> The machine is yours.  The data is yours.  The policy is yours.
+
+---
+
+## Philosophy
+
+Nexus is built on a single non-negotiable principle: **the owner of the local machine has unconditional sovereign control** over all data, all outbound connections, and all integrations.
+
+No data leaves your machine without your explicit permission.  No integration is active by default.  Every gateway call is evaluated against your policy.  Every decision is audited.
+
+---
+
+## How It Works
+
+### The Policy Engine
+
+The `GovernanceEngine` (`core/governance.js`) sits between the APIGateway and all outbound calls.  Every `gateway.call()` invocation is checked against the owner's policy before execution.
+
+**Default policy (safe baseline):**
+```json
+{
+  "version": 1,
+  "owner": "local",
+  "default": "allow_local",
+  "rules": [
+    { "type": "allow", "target": "local.*" },
+    { "type": "allow", "target": "projects.*" },
+    { "type": "allow", "target": "tasks.*" },
+    { "type": "allow", "target": "store.*" },
+    { "type": "allow", "target": "ui.*" },
+    { "type": "deny",  "target": "integrations.*", "reason": "not configured" }
+  ]
+}
+```
+
+All local operations are allowed.  All integrations are denied by default.
+
+### Rule Evaluation
+
+Rules are evaluated **in order, last match wins**.  This means:
+
+```json
+{ "type": "allow", "target": "integrations.*" },
+{ "type": "deny",  "target": "integrations.airtable.*" }
+```
+
+This configuration allows all integrations **except** Airtable — the more specific rule wins.
+
+### Wildcard Targets
+
+| Pattern | Matches |
+|---------|---------|
+| `local.*` | Any local route |
+| `projects.*` | projects.list, projects.create, projects.delete |
+| `integrations.*` | Any integration |
+| `integrations.airtable.*` | Only Airtable calls |
+| `integrations.ai.stream` | Only AI streaming |
+
+---
+
+## Data Classification
+
+Every integration and portal call carries a data classification tag.  The governance engine can enforce data-class-level rules:
+
+| Class | Meaning |
+|-------|---------|
+| `public` | Safe to send to any enabled integration |
+| `internal` | Send only to explicitly trusted integrations |
+| `confidential` | Require explicit per-call owner approval |
+| `restricted` | Never leave the local machine |
+
+---
+
+## Audit Log
+
+Every gateway call is logged to the audit trail:
+
+```json
+{
+  "id":      "a3f9b2d1",
+  "ts":      1720000000000,
+  "route":   "integrations.airtable.sync",
+  "allowed": true,
+  "rule":    "integrations.airtable.*",
+  "reason":  null
+}
+```
+
+The audit log is:
+- Stored in IndexedDB (`nexus_local` → `audit_log`)
+- Limited to the last 1000 entries in memory (full log on disk via backend)
+- Visible in real-time in the Governance panel
+- Exportable as JSON from the Governance panel
+
+---
+
+## Enabling an Integration
+
+From the **Governance panel → Integration Permissions**, toggle an integration on.
+
+Or programmatically:
+
+```js
+await governance.enableIntegration('airtable');
+// Adds: { type: 'allow', target: 'integrations.airtable.*' } to policy
+```
+
+To disable:
+
+```js
+await governance.disableIntegration('airtable');
+// Adds: { type: 'deny', target: 'integrations.airtable.*', reason: 'disabled by owner' }
+```
+
+Changes take effect **immediately** — no reload required.  The policy is persisted to IndexedDB.
+
+---
+
+## Policy Files
+
+The policy can also be exported, version-controlled, and imported:
+
+```bash
+# Export from Governance panel → Export button
+# Results in nexus-audit-{timestamp}.json
+
+# Import: paste into the policy editor and click Save
+```
+
+This means your governance configuration is **auditable**, **shareable** (policy only, not credentials), and **reproducible** across machines.
+
+---
+
+## Threat Model
+
+| Threat | Mitigation |
+|--------|-----------|
+| Malicious browser extension reads local data | IndexedDB is origin-scoped; served from localhost |
+| Third-party script exfiltrates data | No CDN scripts loaded; all assets local or pre-approved Google Fonts |
+| CSRF attack on backend API | CORS restricted to specific local origin |
+| Backend exposed to network | Binds to 127.0.0.1 only by default |
+| API keys leaked in logs | Keys stored in IndexedDB, never written to disk logs |
+| Integration sends data without permission | GovernanceEngine deny-by-default enforces at gateway level |
+
+---
+
+## Multi-machine Sync (Future)
+
+The governance architecture is designed to support future peer-to-peer sync between machines you own:
+
+1. Each machine has its own governance policy
+2. Sync events carry a source machine ID
+3. Receiving machine's governance engine evaluates whether to accept the sync
+4. No central server; sync is owner-to-owner via encrypted transport
+
+This is a future capability — stub hooks are in the EventBus and LocalStore.

--- a/nexus/docs/INTEGRATION_GUIDE.md
+++ b/nexus/docs/INTEGRATION_GUIDE.md
@@ -1,0 +1,284 @@
+# NEXUS Integration Guide
+
+> Connect your external ecosystem while keeping full local control.
+
+---
+
+## Overview
+
+Nexus integrations follow a consistent pattern:
+
+1. **Configure** — Add credentials in the Integrations panel
+2. **Connect** — Test the connection and register gateway routes
+3. **Govern** — Enable the integration in the Governance panel
+4. **Sync** — Pull/push data through the gateway
+
+All integration calls are gated by the GovernanceEngine.  No data leaves your machine until you explicitly enable the integration.
+
+---
+
+## Airtable
+
+### Setup
+
+1. Go to **Integrations → Airtable**
+2. Enter your Airtable **API Key** (Settings → Developer Hub → Personal Access Token)
+3. Enter your **Base ID** (found in the Airtable API docs URL for your base)
+4. Click **Connect** — Nexus will test the connection
+5. Go to **Governance → Integration Permissions** and toggle Airtable **on**
+
+### Required Base Structure
+
+Create two tables in your Airtable base:
+
+**Projects table**
+| Field | Type |
+|-------|------|
+| Name | Single line text |
+| Description | Long text |
+| Status | Single select (active, paused, planning, completed) |
+| Color | Single select (cyan, yellow, green, shale) |
+| UpdatedAt | Date (ISO 8601) |
+
+**Tasks table**
+| Field | Type |
+|-------|------|
+| Title | Single line text |
+| Description | Long text |
+| Status | Single select (todo, in-progress, review, done) |
+| ProjectId | Single line text |
+| Tags | Multiple select |
+
+### Sync Behavior
+
+- **Pull** — Remote records overwrite local records (last `_updatedAt` wins)
+- **Push** — Local records without an `airtableId` are created in Airtable
+- **Auto-sync** — Enable polling via `airtable.startAutoSync(300000)` (5-minute interval)
+- **Manual** — Click **↻ Sync Now** in the Integrations panel or on the Dashboard
+
+### Code
+
+```js
+import { airtable } from './nexus/integrations/airtable.js';
+
+await airtable.connect({ apiKey: '...', baseId: 'appXXXXXXXX' });
+await airtable.syncAll();
+const projects = await airtable.fetchProjects();
+```
+
+---
+
+## AI (Claude)
+
+### Setup
+
+1. Go to **Integrations → AI (Claude)**
+2. Enter your **Anthropic API Key** (console.anthropic.com → API Keys)
+3. Select a model (Sonnet 4.6 is recommended)
+4. Click **Connect**
+5. Enable in **Governance → Integration Permissions**
+
+### Capabilities
+
+| Method | Description |
+|--------|-------------|
+| `ai.ask(prompt, context)` | General Q&A with local context |
+| `ai.summarizeProject(project, tasks)` | 2-3 sentence project health summary |
+| `ai.generateTasks(description)` | Parse description into task checklist |
+| `ai.analyzeHealth(projects, tasks)` | Ecosystem health check |
+| `ai.searchLocal(query)` | Natural-language search across all local data |
+| `ai.stream(prompt, onChunk)` | Streaming response for real-time output |
+
+### Code
+
+```js
+import { ai } from './nexus/integrations/ai.js';
+
+await ai.connect({ apiKey: 'sk-ant-...', model: 'claude-sonnet-4-6' });
+
+// Ask a question
+const answer = await ai.ask('What are my top priorities today?');
+
+// Generate tasks
+const tasks = await ai.generateTasks(
+  'Build a data pipeline that scrapes news headlines and categorizes them by topic'
+);
+// returns: [{ id, title, status:'todo', _source:'ai' }, ...]
+
+// Stream a response
+for await (const chunk of ai.stream('Summarize my project backlog')) {
+  process.stdout.write(chunk);
+}
+```
+
+### Data Privacy
+
+By default, AI calls include a system prompt that scopes Claude to the local context.  The governance engine will block AI calls if the integration is disabled.  Credentials are stored in IndexedDB and never written to disk.
+
+---
+
+## GitHub
+
+### Setup
+
+1. Go to **Integrations → GitHub**
+2. Create a **Personal Access Token** at github.com → Settings → Developer Settings → PAT
+   - Required scopes: `repo`, `workflow`, `read:user`
+3. Enter your PAT and default repository (`owner/repo`)
+4. Click **Connect**
+5. Enable in Governance
+
+### Features
+
+**Import issues as tasks:**
+```js
+import { github } from './nexus/integrations/github.js';
+
+await github.connect({ token: 'ghp_...', defaultRepo: 'jpuskas3/javelin' });
+
+// Link a project to a repo
+await github.linkProject('proj_abc123', 'jpuskas3/javelin');
+
+// Pull all open issues as tasks
+const tasks = await github.syncIssues('proj_abc123');
+```
+
+**Trigger CI workflows:**
+```js
+await github.triggerWorkflow('jpuskas3/javelin', 'deploy.yml', 'main', {
+  environment: 'production',
+});
+```
+
+**Monitor CI status from Labs panel:**
+```js
+const run = await github.latestRunStatus('jpuskas3/javelin');
+// { conclusion: 'success', status: 'completed', ... }
+```
+
+---
+
+## Portals (Custom REST APIs)
+
+Portals allow you to connect **any REST API** to Nexus without writing a custom integration module.
+
+### Register a portal
+
+```js
+import { portals } from './nexus/integrations/portals.js';
+
+portals.register({
+  name:      'notion',
+  label:     'Notion Workspace',
+  baseUrl:   'https://api.notion.com/v1',
+  auth:      { type: 'bearer', token: 'secret_xxx' },
+  dataClass: 'internal',
+  actions: {
+    listDatabases: {
+      method: 'GET',
+      path:   '/databases',
+    },
+    queryDatabase: {
+      method: 'POST',
+      path:   '/databases/{databaseId}/query',
+    },
+    createPage: {
+      method:       'POST',
+      path:         '/pages',
+      bodyTemplate: {
+        parent: { database_id: '{databaseId}' },
+        properties: { title: [{ text: { content: '{title}' } }] },
+      },
+    },
+  },
+});
+```
+
+### Invoke a portal action
+
+```js
+const pages = await portals.invoke('notion', 'queryDatabase', {
+  databaseId: 'abc123',
+});
+
+await portals.invoke('notion', 'createPage', {
+  databaseId: 'abc123',
+  title: 'New Project Page',
+});
+```
+
+### Auth types supported
+
+| Type | Config fields |
+|------|--------------|
+| `none` | (no auth) |
+| `bearer` | `token` |
+| `apikey` | `header` (optional, default `X-API-Key`), `key` |
+| `basic` | `username`, `password` |
+| `oauth2` | `accessToken` (you manage the OAuth2 flow) |
+
+### Governance for portals
+
+Each portal can be individually enabled/disabled:
+
+```js
+await governance.enableIntegration('portals.notion');
+await governance.disableIntegration('portals.notion');
+```
+
+Or toggle all portals:
+```js
+await governance.enableIntegration('portals');
+```
+
+---
+
+## Writing a Custom Integration Module
+
+If a Portal config isn't enough (e.g. you need OAuth2 flow, websocket, custom auth):
+
+1. Create `nexus/integrations/{name}.js`
+2. Export a singleton class following the pattern:
+
+```js
+class MyIntegration {
+  #apiKey    = null;
+  #connected = false;
+
+  async connect({ apiKey }) {
+    this.#apiKey   = apiKey;
+    this.#connected = await this.testConnection();
+    if (!this.#connected) throw new Error('Connection failed');
+    this.#registerRoutes();
+    bus.emit('integrations:myservice:connected', {});
+    return true;
+  }
+
+  get connected() { return this.#connected; }
+
+  #registerRoutes() {
+    gateway.remote('myservice', 'GET', '/data', (p) => this.fetchData(p));
+  }
+
+  async fetchData(params) { /* ... */ }
+}
+
+export const myService = new MyIntegration();
+export default myService;
+```
+
+3. Add a config card to the Integrations panel in `nexus.html`
+4. Add a governance toggle in the Governance panel
+5. Document the integration in this guide
+
+---
+
+## Integration Status Reference
+
+| Status | Meaning |
+|--------|---------|
+| 🔴 Disconnected | Not configured or connection failed |
+| 🟡 Connecting | Test in progress |
+| 🟢 Connected | Active and governance-allowed |
+| 🔒 Blocked | Governance policy is denying calls |
+| ↻ Syncing | Bidirectional sync in progress |

--- a/nexus/integrations/ai.js
+++ b/nexus/integrations/ai.js
@@ -1,0 +1,265 @@
+/**
+ * nexus/integrations/ai.js
+ * ============================================================================
+ * NEXUS AI Integration — Claude (Anthropic)
+ *
+ * Provides AI-powered project intelligence using the Claude API.  Capabilities:
+ *
+ *   • Project summaries and health analysis
+ *   • Task generation from project descriptions
+ *   • Smart search across local data
+ *   • Code assistance for lab scripts
+ *   • Natural-language governance rule suggestions
+ *
+ * All prompts include a system context that scopes Claude to the local
+ * workstation data — no data is sent to AI without explicit governance allow.
+ *
+ * WIRE-UP CHECKLIST
+ * -----------------
+ * 1. User adds Anthropic API key in Integrations panel
+ * 2. Call AIIntegration.connect({ apiKey, model })
+ * 3. Use .ask(), .summarizeProject(), .generateTasks(), etc.
+ * 4. All calls are gated by governance.allow('integrations.ai.*')
+ *
+ * Model IDs (2026)
+ * ----------------
+ *   claude-sonnet-4-6          Standard, balanced
+ *   claude-opus-4-7            Most capable
+ *   claude-haiku-4-5-20251001  Fastest, lowest cost
+ */
+
+import { bus      } from '../core/bus.js';
+import { store    } from '../core/store.js';
+import { gateway  } from '../core/gateway.js';
+import { governance } from '../core/governance.js';
+
+const ANTHROPIC_API  = 'https://api.anthropic.com/v1/messages';
+const DEFAULT_MODEL  = 'claude-sonnet-4-6';
+const MAX_TOKENS     = 2048;
+
+const SYSTEM_PROMPT = `You are the AI assistant embedded in Nexus Workstation, a local-first
+project management system running on the owner's personal machine.
+
+Your role:
+- Help the owner organize, plan, and execute projects efficiently
+- Analyze project health, surface blockers, and suggest next steps
+- Generate well-structured tasks from project descriptions
+- Keep all responses concise and actionable
+- Respect that this is a local sovereign ecosystem — never suggest uploading
+  data to third parties unless the owner explicitly requests it
+
+Response format: Always respond in plain prose or structured markdown.
+For task lists, use checkboxes (- [ ] task).
+For code, use fenced code blocks.`;
+
+class AIIntegration {
+  #apiKey    = null;
+  #model     = DEFAULT_MODEL;
+  #connected = false;
+
+  // ─── Connection ────────────────────────────────────────────────────
+
+  async connect({ apiKey, model = DEFAULT_MODEL }) {
+    this.#apiKey = apiKey;
+    this.#model  = model;
+
+    const ok = await this.testConnection();
+    if (!ok) throw new Error('AI connection test failed — check your Anthropic API key');
+
+    this.#connected = true;
+    this.#registerRoutes();
+
+    await store.set('settings', 'ai_config', {
+      model,
+      connectedAt: Date.now(),
+      status: 'connected',
+    });
+
+    bus.emit('integrations:ai:connected', { model });
+    return true;
+  }
+
+  disconnect() {
+    this.#connected = false;
+    this.#apiKey    = null;
+    bus.emit('integrations:ai:disconnected', {});
+  }
+
+  get connected() { return this.#connected; }
+
+  // ─── Core request ──────────────────────────────────────────────────
+
+  async #request(messages, opts = {}) {
+    if (!this.#apiKey) throw new Error('AI: not connected — add API key in Integrations');
+
+    if (!governance.allow('integrations.ai.request')) {
+      throw new Error('[Governance] AI requests are blocked by policy');
+    }
+
+    bus.emit('integrations:ai:request', { messages });
+
+    const response = await fetch(ANTHROPIC_API, {
+      method:  'POST',
+      headers: {
+        'x-api-key':         this.#apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type':      'application/json',
+      },
+      body: JSON.stringify({
+        model:      opts.model ?? this.#model,
+        max_tokens: opts.maxTokens ?? MAX_TOKENS,
+        system:     opts.system ?? SYSTEM_PROMPT,
+        messages,
+      }),
+    });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error(`Claude API error: ${err.error?.message ?? response.statusText}`);
+    }
+
+    const data = await response.json();
+    const text = data.content?.[0]?.text ?? '';
+
+    bus.emit('integrations:ai:response', { text, usage: data.usage });
+    return text;
+  }
+
+  async testConnection() {
+    try {
+      await this.#request([{ role: 'user', content: 'Reply with exactly: ok' }],
+        { maxTokens: 10 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // ─── Gateway route registration ────────────────────────────────────
+
+  #registerRoutes() {
+    gateway.remote('ai', 'POST', '/ask',             (p) => this.ask(p.prompt, p.context));
+    gateway.remote('ai', 'POST', '/summarize',       (p) => this.summarizeProject(p.project, p.tasks));
+    gateway.remote('ai', 'POST', '/generate-tasks',  (p) => this.generateTasks(p.description));
+    gateway.remote('ai', 'POST', '/analyze-health',  (p) => this.analyzeHealth(p.projects, p.tasks));
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────
+
+  async ask(prompt, context = null) {
+    const messages = [{ role: 'user', content: context ? `Context:\n${context}\n\n${prompt}` : prompt }];
+    return this.#request(messages);
+  }
+
+  async summarizeProject(project, tasks = []) {
+    const doneTasks = tasks.filter(t => t.status === 'done').length;
+    const context   = `Project: ${project.name}
+Description: ${project.description ?? 'None'}
+Status: ${project.status}
+Tasks: ${tasks.length} total, ${doneTasks} done (${tasks.length ? Math.round(doneTasks/tasks.length*100) : 0}% complete)
+Open tasks: ${tasks.filter(t => t.status !== 'done').map(t => t.title).join(', ') || 'None'}`;
+
+    return this.ask('Write a 2-3 sentence project health summary and identify any blockers or next steps.', context);
+  }
+
+  async generateTasks(projectDescription) {
+    const prompt = `Given this project description, generate 5-8 concrete, actionable tasks.
+Format each as: - [ ] Task title (brief description if needed)
+
+Project description:
+${projectDescription}`;
+
+    const response = await this.ask(prompt);
+    return this.#parseTaskList(response);
+  }
+
+  async analyzeHealth(projects = [], tasks = []) {
+    const context = `Total projects: ${projects.length}
+Active: ${projects.filter(p => p.status === 'active').length}
+Total tasks: ${tasks.length}
+Done: ${tasks.filter(t => t.status === 'done').length}
+Overdue: ${tasks.filter(t => t.dueDate && new Date(t.dueDate) < new Date() && t.status !== 'done').length}`;
+
+    return this.ask('Give a brief ecosystem health check (2-4 bullets) with top priority recommendation.', context);
+  }
+
+  async searchLocal(query) {
+    const [projects, tasks] = await Promise.all([
+      store.getAll('projects'),
+      store.getAll('tasks'),
+    ]);
+
+    const context = `Local data summary:
+Projects: ${JSON.stringify(projects.map(p => ({ name: p.name, status: p.status, description: p.description })))}
+Tasks: ${JSON.stringify(tasks.map(t => ({ title: t.title, status: t.status, projectId: t.projectId })))}`;
+
+    return this.ask(`Search query: "${query}"\nFind and summarize all relevant projects and tasks.`, context);
+  }
+
+  // ─── Streaming support ─────────────────────────────────────────────
+
+  async *stream(prompt, onChunk) {
+    if (!this.#apiKey) throw new Error('AI: not connected');
+    if (!governance.allow('integrations.ai.stream')) {
+      throw new Error('[Governance] AI streaming is blocked by policy');
+    }
+
+    const response = await fetch(ANTHROPIC_API, {
+      method:  'POST',
+      headers: {
+        'x-api-key':         this.#apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type':      'application/json',
+      },
+      body: JSON.stringify({
+        model:      this.#model,
+        max_tokens: MAX_TOKENS,
+        system:     SYSTEM_PROMPT,
+        stream:     true,
+        messages:   [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        try {
+          const data = JSON.parse(line.slice(6));
+          if (data.type === 'content_block_delta') {
+            const chunk = data.delta?.text ?? '';
+            if (chunk && onChunk) onChunk(chunk);
+            yield chunk;
+          }
+        } catch { /* skip malformed SSE */ }
+      }
+    }
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────
+
+  #parseTaskList(text) {
+    return text
+      .split('\n')
+      .filter(l => l.trim().startsWith('- [ ]') || l.trim().startsWith('- [x]'))
+      .map(l => ({
+        id:     `task_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+        title:  l.replace(/^- \[[ x]\]\s*/, '').trim(),
+        status: l.includes('[x]') ? 'done' : 'todo',
+        _source:'ai',
+      }));
+  }
+}
+
+export const ai = new AIIntegration();
+export default ai;

--- a/nexus/integrations/airtable.js
+++ b/nexus/integrations/airtable.js
@@ -1,0 +1,239 @@
+/**
+ * nexus/integrations/airtable.js
+ * ============================================================================
+ * NEXUS Airtable Integration
+ *
+ * Provides bidirectional sync between the Nexus LocalStore and an Airtable
+ * base.  All network calls are routed through the APIGateway and are subject
+ * to Governance policy.
+ *
+ * WIRE-UP CHECKLIST
+ * -----------------
+ * 1. User adds API key + Base ID in Integrations panel
+ * 2. Call AirtableIntegration.connect({ apiKey, baseId })
+ * 3. Optionally call .startAutoSync(intervalMs) for background polling
+ * 4. gateway.remote() handlers are registered automatically on connect
+ *
+ * Data flow
+ * ---------
+ *   Local Projects  ─sync─→  Airtable Table "Projects"
+ *   Local Tasks     ─sync─→  Airtable Table "Tasks"
+ *   Airtable records ←─poll─ Nexus (every N minutes)
+ *
+ * Conflict resolution: last-write-wins by _updatedAt timestamp.
+ *
+ * REST API reference: https://airtable.com/developers/web/api/introduction
+ */
+
+import { bus      } from '../core/bus.js';
+import { store    } from '../core/store.js';
+import { gateway  } from '../core/gateway.js';
+
+const AIRTABLE_BASE_URL = 'https://api.airtable.com/v0';
+
+class AirtableIntegration {
+  #apiKey  = null;
+  #baseId  = null;
+  #connected = false;
+  #syncTimer = null;
+
+  // ─── Connection ────────────────────────────────────────────────────
+
+  async connect({ apiKey, baseId }) {
+    this.#apiKey  = apiKey;
+    this.#baseId  = baseId;
+
+    const ok = await this.testConnection();
+    if (!ok) throw new Error('Airtable connection test failed — check API key and Base ID');
+
+    this.#connected = true;
+    this.#registerRoutes();
+
+    await store.set('settings', 'airtable_config', {
+      baseId,
+      connectedAt: Date.now(),
+      status: 'connected',
+    });
+
+    bus.emit('integrations:airtable:connected', { baseId });
+    return true;
+  }
+
+  disconnect() {
+    this.stopAutoSync();
+    this.#connected = false;
+    this.#apiKey    = null;
+    this.#baseId    = null;
+    bus.emit('integrations:airtable:disconnected', {});
+  }
+
+  get connected() { return this.#connected; }
+
+  // ─── API helpers ───────────────────────────────────────────────────
+
+  async #request(method, path, body = null) {
+    if (!this.#apiKey) throw new Error('Airtable: not connected');
+
+    const response = await fetch(`${AIRTABLE_BASE_URL}/${this.#baseId}${path}`, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${this.#apiKey}`,
+        'Content-Type':  'application/json',
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error(`Airtable ${method} ${path}: ${err.error?.message ?? response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async testConnection() {
+    try {
+      await this.#request('GET', '/Projects?maxRecords=1');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // ─── Gateway route registration ────────────────────────────────────
+
+  #registerRoutes() {
+    gateway.remote('airtable', 'GET',  '/projects',    (p) => this.fetchProjects(p));
+    gateway.remote('airtable', 'POST', '/projects',    (p) => this.pushProject(p));
+    gateway.remote('airtable', 'GET',  '/tasks',       (p) => this.fetchTasks(p));
+    gateway.remote('airtable', 'POST', '/tasks',       (p) => this.pushTask(p));
+    gateway.remote('airtable', 'DELETE', '/projects',  (p) => this.deleteProject(p));
+  }
+
+  // ─── Projects ──────────────────────────────────────────────────────
+
+  async fetchProjects() {
+    const data     = await this.#request('GET', '/Projects?view=Grid+view');
+    const records  = data.records ?? [];
+
+    return records.map(r => ({
+      id:          r.id,
+      name:        r.fields['Name']        ?? 'Untitled',
+      description: r.fields['Description'] ?? '',
+      status:      (r.fields['Status']     ?? 'active').toLowerCase(),
+      color:       (r.fields['Color']      ?? 'cyan').toLowerCase(),
+      airtableId:  r.id,
+      _source:     'airtable',
+    }));
+  }
+
+  async pushProject(project) {
+    const fields = {
+      'Name':        project.name,
+      'Description': project.description ?? '',
+      'Status':      project.status ?? 'active',
+      'Color':       project.color  ?? 'cyan',
+      'UpdatedAt':   new Date(project._updatedAt ?? Date.now()).toISOString(),
+    };
+
+    if (project.airtableId) {
+      return this.#request('PATCH', `/Projects/${project.airtableId}`, { fields });
+    } else {
+      return this.#request('POST', '/Projects', { records: [{ fields }] });
+    }
+  }
+
+  async deleteProject({ airtableId }) {
+    if (!airtableId) return;
+    return this.#request('DELETE', `/Projects/${airtableId}`);
+  }
+
+  // ─── Tasks ─────────────────────────────────────────────────────────
+
+  async fetchTasks({ projectId } = {}) {
+    let url = '/Tasks?view=Grid+view';
+    if (projectId) url += `&filterByFormula={ProjectId}="${projectId}"`;
+
+    const data    = await this.#request('GET', url);
+    const records = data.records ?? [];
+
+    return records.map(r => ({
+      id:         r.id,
+      title:      r.fields['Title']      ?? 'Untitled',
+      description:r.fields['Description'] ?? '',
+      status:     (r.fields['Status']    ?? 'todo').toLowerCase(),
+      projectId:  r.fields['ProjectId']  ?? null,
+      tags:       r.fields['Tags']       ?? [],
+      airtableId: r.id,
+      _source:    'airtable',
+    }));
+  }
+
+  async pushTask(task) {
+    const fields = {
+      'Title':       task.title,
+      'Description': task.description ?? '',
+      'Status':      task.status ?? 'todo',
+      'ProjectId':   task.projectId ?? '',
+      'Tags':        task.tags ?? [],
+    };
+
+    if (task.airtableId) {
+      return this.#request('PATCH', `/Tasks/${task.airtableId}`, { fields });
+    } else {
+      return this.#request('POST', '/Tasks', { records: [{ fields }] });
+    }
+  }
+
+  // ─── Full bidirectional sync ────────────────────────────────────────
+
+  async syncAll() {
+    bus.emit('integrations:airtable:sync_start', {});
+
+    try {
+      // Pull remote → local (merge by id)
+      const [remoteProjects, remoteTasks] = await Promise.all([
+        this.fetchProjects(),
+        this.fetchTasks(),
+      ]);
+
+      for (const p of remoteProjects) await store.set('projects', p.id, p);
+      for (const t of remoteTasks)   await store.set('tasks',    t.id, t);
+
+      // Push local → remote (only records without airtableId)
+      const localProjects = await store.query('projects', p => !p.airtableId);
+      const localTasks    = await store.query('tasks',    t => !t.airtableId);
+
+      await Promise.allSettled([
+        ...localProjects.map(p => this.pushProject(p)),
+        ...localTasks.map(t    => this.pushTask(t)),
+      ]);
+
+      bus.emit('integrations:airtable:sync_complete', {
+        projects: remoteProjects.length,
+        tasks:    remoteTasks.length,
+      });
+
+      return { ok: true, projects: remoteProjects.length, tasks: remoteTasks.length };
+    } catch (err) {
+      bus.emit('integrations:airtable:sync_error', { error: err.message });
+      throw err;
+    }
+  }
+
+  // ─── Auto-sync ─────────────────────────────────────────────────────
+
+  startAutoSync(intervalMs = 5 * 60 * 1000) {
+    this.stopAutoSync();
+    this.#syncTimer = setInterval(() => {
+      if (navigator.onLine && this.#connected) this.syncAll().catch(console.warn);
+    }, intervalMs);
+  }
+
+  stopAutoSync() {
+    if (this.#syncTimer) { clearInterval(this.#syncTimer); this.#syncTimer = null; }
+  }
+}
+
+export const airtable = new AirtableIntegration();
+export default airtable;

--- a/nexus/integrations/github.js
+++ b/nexus/integrations/github.js
@@ -1,0 +1,195 @@
+/**
+ * nexus/integrations/github.js
+ * ============================================================================
+ * NEXUS GitHub Integration
+ *
+ * Links GitHub repositories to Nexus projects, enabling:
+ *   • Import GitHub Issues as Nexus tasks
+ *   • Create GitHub Issues from Nexus tasks
+ *   • Monitor CI/CD status for linked repos
+ *   • Trigger workflow dispatches from the Labs panel
+ *   • Sync commit activity to the Dashboard activity feed
+ *
+ * WIRE-UP CHECKLIST
+ * -----------------
+ * 1. User adds Personal Access Token (PAT) + default repo in Integrations panel
+ * 2. Call GitHubIntegration.connect({ token, defaultRepo })
+ * 3. Link a project to a repo via .linkProject(projectId, 'owner/repo')
+ * 4. Call .syncIssues(projectId) to pull issues as tasks
+ *
+ * Required PAT scopes: repo, workflow, read:user
+ */
+
+import { bus      } from '../core/bus.js';
+import { store    } from '../core/store.js';
+import { gateway  } from '../core/gateway.js';
+import { governance } from '../core/governance.js';
+
+const GITHUB_API  = 'https://api.github.com';
+
+class GitHubIntegration {
+  #token       = null;
+  #defaultRepo = null;
+  #connected   = false;
+
+  // ─── Connection ────────────────────────────────────────────────────
+
+  async connect({ token, defaultRepo }) {
+    this.#token       = token;
+    this.#defaultRepo = defaultRepo;
+
+    const user = await this.getMe();
+    if (!user) throw new Error('GitHub connection failed — check Personal Access Token');
+
+    this.#connected = true;
+    this.#registerRoutes();
+
+    await store.set('settings', 'github_config', {
+      login:       user.login,
+      defaultRepo,
+      connectedAt: Date.now(),
+      status:      'connected',
+    });
+
+    bus.emit('integrations:github:connected', { login: user.login, defaultRepo });
+    return user;
+  }
+
+  disconnect() {
+    this.#connected = false;
+    this.#token     = null;
+    bus.emit('integrations:github:disconnected', {});
+  }
+
+  get connected() { return this.#connected; }
+
+  // ─── API helpers ───────────────────────────────────────────────────
+
+  async #request(method, path, body = null) {
+    if (!this.#token) throw new Error('GitHub: not connected');
+    if (!governance.allow('integrations.github.request')) {
+      throw new Error('[Governance] GitHub requests are blocked by policy');
+    }
+
+    const response = await fetch(`${GITHUB_API}${path}`, {
+      method,
+      headers: {
+        'Authorization': `Bearer ${this.#token}`,
+        'Accept':        'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(body ? { 'Content-Type': 'application/json' } : {}),
+      },
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error(`GitHub ${method} ${path}: ${err.message ?? response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  // ─── Gateway routes ────────────────────────────────────────────────
+
+  #registerRoutes() {
+    gateway.remote('github', 'GET',  '/issues',   (p) => this.listIssues(p.repo, p.state));
+    gateway.remote('github', 'POST', '/issues',   (p) => this.createIssue(p.repo, p.title, p.body));
+    gateway.remote('github', 'GET',  '/commits',  (p) => this.listCommits(p.repo));
+    gateway.remote('github', 'GET',  '/workflows',(p) => this.listWorkflows(p.repo));
+    gateway.remote('github', 'POST', '/dispatch', (p) => this.triggerWorkflow(p.repo, p.workflowId, p.ref, p.inputs));
+  }
+
+  // ─── User ──────────────────────────────────────────────────────────
+
+  async getMe() {
+    try {
+      return await this.#request('GET', '/user');
+    } catch {
+      return null;
+    }
+  }
+
+  // ─── Issues ────────────────────────────────────────────────────────
+
+  async listIssues(repo = this.#defaultRepo, state = 'open') {
+    const data = await this.#request('GET', `/repos/${repo}/issues?state=${state}&per_page=50`);
+    return data.map(i => ({
+      id:          `gh_issue_${i.number}`,
+      title:       i.title,
+      description: i.body ?? '',
+      status:      i.state === 'closed' ? 'done' : 'todo',
+      tags:        i.labels.map(l => l.name),
+      githubIssue: i.number,
+      githubRepo:  repo,
+      url:         i.html_url,
+      _source:     'github',
+    }));
+  }
+
+  async createIssue(repo = this.#defaultRepo, title, body = '') {
+    return this.#request('POST', `/repos/${repo}/issues`, { title, body });
+  }
+
+  // ─── Issues → Tasks sync ───────────────────────────────────────────
+
+  async syncIssues(projectId, repo = this.#defaultRepo) {
+    const issues = await this.listIssues(repo);
+    for (const issue of issues) {
+      const existing = await store.get('tasks', issue.id);
+      if (!existing || existing._updatedAt < issue._updatedAt) {
+        await store.set('tasks', issue.id, { ...issue, projectId });
+      }
+    }
+    bus.emit('integrations:github:issues_synced', { projectId, count: issues.length });
+    return issues;
+  }
+
+  // ─── Commits ───────────────────────────────────────────────────────
+
+  async listCommits(repo = this.#defaultRepo, perPage = 20) {
+    const data = await this.#request('GET', `/repos/${repo}/commits?per_page=${perPage}`);
+    return data.map(c => ({
+      sha:     c.sha.slice(0, 7),
+      message: c.commit.message.split('\n')[0],
+      author:  c.commit.author.name,
+      date:    c.commit.author.date,
+      url:     c.html_url,
+    }));
+  }
+
+  // ─── Workflows / CI ────────────────────────────────────────────────
+
+  async listWorkflows(repo = this.#defaultRepo) {
+    const data = await this.#request('GET', `/repos/${repo}/actions/workflows`);
+    return data.workflows ?? [];
+  }
+
+  async triggerWorkflow(repo = this.#defaultRepo, workflowId, ref = 'main', inputs = {}) {
+    return this.#request('POST', `/repos/${repo}/actions/workflows/${workflowId}/dispatches`, {
+      ref,
+      inputs,
+    });
+  }
+
+  async latestRunStatus(repo = this.#defaultRepo) {
+    try {
+      const data = await this.#request('GET', `/repos/${repo}/actions/runs?per_page=1`);
+      return data.workflow_runs?.[0] ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  // ─── Link project to repo ──────────────────────────────────────────
+
+  async linkProject(projectId, repo) {
+    const project = await store.get('projects', projectId);
+    if (!project) throw new Error(`Project ${projectId} not found`);
+    await store.set('projects', projectId, { ...project, githubRepo: repo });
+    bus.emit('integrations:github:project_linked', { projectId, repo });
+  }
+}
+
+export const github = new GitHubIntegration();
+export default github;

--- a/nexus/integrations/portals.js
+++ b/nexus/integrations/portals.js
@@ -1,0 +1,197 @@
+/**
+ * nexus/integrations/portals.js
+ * ============================================================================
+ * NEXUS Portal Integration — Multi-service Connector
+ *
+ * Portals are generic, configurable connectors to external web services and
+ * APIs.  Each portal has:
+ *   • A name and base URL
+ *   • Authentication configuration (Bearer, API key header, Basic, OAuth2)
+ *   • A set of actions (GET/POST endpoints)
+ *   • Governance data-classification tags
+ *
+ * This design allows the owner to wire any REST API into Nexus without writing
+ * custom integration code.  Power users can also write Portal plugins (JS
+ * modules that export a portalDefinition object).
+ *
+ * WIRE-UP CHECKLIST
+ * -----------------
+ * 1. Define a portal config (see example below)
+ * 2. Call portals.register(config)
+ * 3. Call portals.invoke(portalName, actionName, params)
+ * 4. All calls are gated by governance.allow('integrations.portals.*')
+ *
+ * Example portal config
+ * ---------------------
+ * {
+ *   name:      'jira',
+ *   label:     'Jira Cloud',
+ *   baseUrl:   'https://yourteam.atlassian.net/rest/api/3',
+ *   auth:      { type: 'basic', username: '...', password: '...' },
+ *   dataClass: 'internal',
+ *   actions: {
+ *     listIssues: { method: 'GET',  path: '/search?jql=project=PROJ' },
+ *     createIssue: { method: 'POST', path: '/issue', bodyTemplate: { fields: { summary: '{title}', project: { key: 'PROJ' } } } },
+ *   }
+ * }
+ */
+
+import { bus      } from '../core/bus.js';
+import { store    } from '../core/store.js';
+import { gateway  } from '../core/gateway.js';
+import { governance } from '../core/governance.js';
+
+class PortalRegistry {
+  #portals = new Map();
+
+  // ─── Registration ──────────────────────────────────────────────────
+
+  register(config) {
+    if (!config.name)    throw new Error('Portal config requires a name');
+    if (!config.baseUrl) throw new Error('Portal config requires a baseUrl');
+
+    const portal = {
+      name:      config.name,
+      label:     config.label ?? config.name,
+      baseUrl:   config.baseUrl.replace(/\/$/, ''),
+      auth:      config.auth ?? { type: 'none' },
+      actions:   config.actions ?? {},
+      dataClass: config.dataClass ?? 'public',
+      enabled:   config.enabled ?? true,
+      createdAt: Date.now(),
+    };
+
+    this.#portals.set(portal.name, portal);
+    this.#registerGatewayRoute(portal);
+
+    store.set('integrations', `portal_${portal.name}`, portal);
+    bus.emit('integrations:portals:registered', { name: portal.name });
+
+    return portal;
+  }
+
+  remove(name) {
+    this.#portals.delete(name);
+    store.delete('integrations', `portal_${name}`);
+    bus.emit('integrations:portals:removed', { name });
+  }
+
+  get(name) { return this.#portals.get(name); }
+
+  list() { return [...this.#portals.values()]; }
+
+  enable(name)  { this.#setEnabled(name, true); }
+  disable(name) { this.#setEnabled(name, false); }
+
+  #setEnabled(name, enabled) {
+    const p = this.#portals.get(name);
+    if (!p) return;
+    p.enabled = enabled;
+    bus.emit(`integrations:portals:${enabled ? 'enabled' : 'disabled'}`, { name });
+  }
+
+  // ─── Gateway route ─────────────────────────────────────────────────
+
+  #registerGatewayRoute(portal) {
+    gateway.remote('portals', 'POST', `/${portal.name}`, async (params) => {
+      return this.invoke(portal.name, params.action, params.data);
+    });
+  }
+
+  // ─── Invocation ────────────────────────────────────────────────────
+
+  async invoke(portalName, actionName, params = {}) {
+    const portal = this.#portals.get(portalName);
+    if (!portal)  throw new Error(`Portal not found: ${portalName}`);
+    if (!portal.enabled) throw new Error(`Portal disabled: ${portalName}`);
+
+    if (!governance.allow(`integrations.portals.${portalName}`)) {
+      throw new Error(`[Governance] Portal blocked: ${portalName}`);
+    }
+
+    const action = portal.actions[actionName];
+    if (!action)  throw new Error(`Action not found: ${actionName} on ${portalName}`);
+
+    const url     = `${portal.baseUrl}${this.#interpolate(action.path, params)}`;
+    const headers = this.#buildHeaders(portal.auth);
+    const body    = action.bodyTemplate ? this.#interpolateObj(action.bodyTemplate, params) : null;
+
+    bus.emit('integrations:portals:invoke', { portal: portalName, action: actionName, url });
+
+    const response = await fetch(url, {
+      method:  action.method ?? 'GET',
+      headers,
+      ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(`Portal ${portalName}/${actionName}: ${response.status} ${err}`);
+    }
+
+    const result = await response.json().catch(() => response.text());
+
+    bus.emit('integrations:portals:result', { portal: portalName, action: actionName });
+    return result;
+  }
+
+  // ─── Auth header builder ───────────────────────────────────────────
+
+  #buildHeaders(auth) {
+    const headers = { 'Content-Type': 'application/json' };
+
+    switch (auth.type) {
+      case 'bearer':
+        headers['Authorization'] = `Bearer ${auth.token}`;
+        break;
+      case 'apikey':
+        headers[auth.header ?? 'X-API-Key'] = auth.key;
+        break;
+      case 'basic':
+        headers['Authorization'] = 'Basic ' + btoa(`${auth.username}:${auth.password}`);
+        break;
+      case 'oauth2':
+        headers['Authorization'] = `Bearer ${auth.accessToken}`;
+        break;
+      // 'none' — no auth header
+    }
+
+    return headers;
+  }
+
+  // ─── Template interpolation ────────────────────────────────────────
+
+  #interpolate(template, params) {
+    return template.replace(/\{(\w+)\}/g, (_, key) => encodeURIComponent(params[key] ?? ''));
+  }
+
+  #interpolateObj(obj, params) {
+    const json = JSON.stringify(obj);
+    const interpolated = json.replace(/"\{(\w+)\}"/g, (_, key) => {
+      const val = params[key];
+      return val === undefined ? '""' : JSON.stringify(val);
+    });
+    return JSON.parse(interpolated);
+  }
+
+  // ─── Persistence (load saved portals on init) ───────────────────────
+
+  async loadSaved() {
+    await store.ready;
+    const saved = await store.query('integrations', r => r.id?.startsWith('portal_'));
+    for (const p of saved) {
+      if (!this.#portals.has(p.name)) {
+        this.#portals.set(p.name, p);
+        this.#registerGatewayRoute(p);
+      }
+    }
+    return saved.length;
+  }
+}
+
+export const portals = new PortalRegistry();
+
+// Load persisted portals on module load
+portals.loadSaved().catch(() => {});
+
+export default portals;

--- a/nexus/nexus.css
+++ b/nexus/nexus.css
@@ -1,0 +1,1252 @@
+/**
+ * nexus/nexus.css
+ * ============================================================================
+ * NEXUS Design System — Reactive Pastel UI
+ *
+ * Palette
+ * -------
+ *   Cyan       hsla(185, 60%, 72%, 1)   #73D8E3   primary accent
+ *   Yellow     hsla(46,  90%, 76%, 1)   #F5D56B   secondary accent
+ *   Sil-Green  hsla(142, 48%, 72%, 1)   #85D9A0   success / active
+ *   Shale      hsla(210, 18%, 38%, 1)   #4E6070   text / structural
+ *   Shale-Dk   hsla(210, 20%, 22%, 1)   #2D3A47   surface dark
+ *   Shale-Dkst hsla(210, 22%, 14%, 1)   #1C2830   background dark
+ *   Glass      hsla(210, 30%, 95%, .08) frosted overlay
+ *
+ * Architecture
+ * ------------
+ *   This file is structured in layers:
+ *     1. Custom properties (tokens)
+ *     2. Reset + base
+ *     3. Layout primitives (grid, flex, sidebar, main)
+ *     4. Component library (cards, buttons, badges, inputs, tables)
+ *     5. Module-specific overrides
+ *     6. Animations & transitions
+ *     7. Reactive states (loading, error, success, offline)
+ *     8. Responsive breakpoints
+ */
+
+/* =========================================================================
+   1. DESIGN TOKENS
+   ========================================================================= */
+
+:root {
+  /* -- Palette -- */
+  --cyan:        hsla(185, 60%, 72%, 1);
+  --cyan-light:  hsla(185, 60%, 86%, 1);
+  --cyan-dark:   hsla(185, 60%, 48%, 1);
+  --cyan-glow:   hsla(185, 80%, 65%, 0.35);
+
+  --yellow:      hsla(46, 90%, 76%, 1);
+  --yellow-light:hsla(46, 90%, 88%, 1);
+  --yellow-dark: hsla(46, 90%, 52%, 1);
+  --yellow-glow: hsla(46, 95%, 68%, 0.35);
+
+  --silgreen:        hsla(142, 48%, 72%, 1);
+  --silgreen-light:  hsla(142, 48%, 86%, 1);
+  --silgreen-dark:   hsla(142, 48%, 48%, 1);
+  --silgreen-glow:   hsla(142, 60%, 65%, 0.35);
+
+  --shale:       hsla(210, 18%, 38%, 1);
+  --shale-mid:   hsla(210, 16%, 52%, 1);
+  --shale-light: hsla(210, 14%, 70%, 1);
+  --shale-dark:  hsla(210, 20%, 22%, 1);
+  --shale-darkest: hsla(210, 22%, 14%, 1);
+
+  /* -- Surfaces -- */
+  --surface-base:    var(--shale-darkest);
+  --surface-raised:  var(--shale-dark);
+  --surface-overlay: hsla(210, 20%, 28%, 1);
+  --surface-glass:   hsla(210, 30%, 95%, 0.06);
+  --surface-glass-border: hsla(185, 60%, 80%, 0.18);
+
+  /* -- Text -- */
+  --text-primary:   hsla(185, 40%, 94%, 1);
+  --text-secondary: hsla(210, 14%, 70%, 1);
+  --text-muted:     hsla(210, 14%, 50%, 1);
+  --text-accent:    var(--cyan);
+  --text-warn:      var(--yellow);
+  --text-success:   var(--silgreen);
+
+  /* -- Borders -- */
+  --border-subtle:  hsla(185, 30%, 40%, 0.25);
+  --border-active:  hsla(185, 60%, 65%, 0.6);
+  --border-glow:    hsla(185, 80%, 65%, 0.4);
+
+  /* -- Shadows -- */
+  --shadow-sm:   0 1px 4px hsla(210, 30%, 5%, 0.5);
+  --shadow-md:   0 4px 16px hsla(210, 30%, 5%, 0.55);
+  --shadow-lg:   0 8px 32px hsla(210, 30%, 5%, 0.6);
+  --shadow-cyan: 0 0 20px var(--cyan-glow);
+  --shadow-glow: 0 0 40px var(--cyan-glow), 0 4px 16px hsla(210, 30%, 5%, 0.5);
+
+  /* -- Layout -- */
+  --header-h:     60px;
+  --footer-h:     52px;
+  --sidebar-w:    220px;
+  --sidebar-w-sm: 60px;
+  --radius-sm:    6px;
+  --radius-md:    10px;
+  --radius-lg:    16px;
+  --radius-xl:    24px;
+
+  /* -- Typography -- */
+  --font-sans:  'Inter', 'Segoe UI', system-ui, sans-serif;
+  --font-mono:  'JetBrains Mono', 'Fira Code', monospace;
+  --font-xs:    0.72rem;
+  --font-sm:    0.82rem;
+  --font-base:  0.93rem;
+  --font-md:    1.05rem;
+  --font-lg:    1.2rem;
+  --font-xl:    1.5rem;
+  --font-2xl:   2rem;
+
+  /* -- Motion -- */
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --dur-fast:    120ms;
+  --dur-normal:  240ms;
+  --dur-slow:    400ms;
+
+  /* -- Z-index scale -- */
+  --z-base:    0;
+  --z-raised:  10;
+  --z-header:  100;
+  --z-modal:   200;
+  --z-toast:   300;
+  --z-cursor:  400;
+}
+
+/* =========================================================================
+   2. RESET + BASE
+   ========================================================================= */
+
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin:     0;
+  padding:    0;
+}
+
+html {
+  font-size:              15px;
+  -webkit-font-smoothing: antialiased;
+  text-rendering:         optimizeLegibility;
+}
+
+body {
+  font-family:     var(--font-sans);
+  font-size:       var(--font-base);
+  color:           var(--text-primary);
+  background:      var(--surface-base);
+  min-height:      100vh;
+  overflow:        hidden;
+  line-height:     1.55;
+}
+
+a { color: var(--cyan); text-decoration: none; }
+a:hover { color: var(--cyan-light); text-decoration: underline; }
+
+code, pre { font-family: var(--font-mono); }
+
+::-webkit-scrollbar             { width: 5px; height: 5px; }
+::-webkit-scrollbar-track       { background: transparent; }
+::-webkit-scrollbar-thumb       { background: var(--shale); border-radius: 99px; }
+::-webkit-scrollbar-thumb:hover { background: var(--shale-mid); }
+
+/* =========================================================================
+   3. LAYOUT PRIMITIVES
+   ========================================================================= */
+
+/* -- App shell -- */
+.nexus-shell {
+  display:     grid;
+  grid-template-columns: var(--sidebar-w) 1fr var(--sidebar-w);
+  grid-template-rows:    var(--header-h) 1fr var(--footer-h);
+  grid-template-areas:
+    "header  header  header"
+    "left    main    right"
+    "footer  footer  footer";
+  height:  100vh;
+  width:   100vw;
+  overflow: hidden;
+}
+
+.nexus-shell.sidebar-collapsed {
+  grid-template-columns: var(--sidebar-w-sm) 1fr var(--sidebar-w-sm);
+}
+
+/* -- Header -- */
+.nexus-header {
+  grid-area:      header;
+  z-index:        var(--z-header);
+  display:        flex;
+  align-items:    center;
+  gap:            12px;
+  padding:        0 20px;
+  background:     hsla(210, 22%, 11%, 0.92);
+  backdrop-filter:blur(12px);
+  border-bottom:  1px solid var(--border-subtle);
+  box-shadow:     var(--shadow-sm);
+}
+
+.nexus-logo {
+  display:     flex;
+  align-items: center;
+  gap:         8px;
+  font-size:   var(--font-lg);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color:       var(--text-primary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.nexus-logo-mark {
+  width:  32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--cyan) 0%, var(--silgreen) 100%);
+  display:       flex;
+  align-items:   center;
+  justify-content: center;
+  font-size:     16px;
+  font-weight:   900;
+  color:         var(--shale-darkest);
+  box-shadow:    var(--shadow-cyan);
+  animation:     logo-pulse 4s ease-in-out infinite;
+}
+
+@keyframes logo-pulse {
+  0%, 100% { box-shadow: 0 0 12px var(--cyan-glow); }
+  50%       { box-shadow: 0 0 24px var(--cyan-glow), 0 0 48px var(--cyan-glow); }
+}
+
+.nexus-nav {
+  display:     flex;
+  align-items: center;
+  gap:         4px;
+  flex:        1;
+  overflow-x:  auto;
+  overflow-y:  hidden;
+  scrollbar-width: none;
+}
+
+.nexus-nav-btn {
+  display:        flex;
+  align-items:    center;
+  gap:            6px;
+  padding:        6px 14px;
+  border:         1px solid transparent;
+  border-radius:  var(--radius-md);
+  background:     transparent;
+  color:          var(--text-secondary);
+  font-size:      var(--font-sm);
+  font-weight:    500;
+  cursor:         pointer;
+  white-space:    nowrap;
+  transition:     all var(--dur-normal) var(--ease-smooth);
+  position:       relative;
+}
+
+.nexus-nav-btn:hover {
+  background: var(--surface-glass);
+  color:      var(--text-primary);
+  border-color: var(--border-subtle);
+}
+
+.nexus-nav-btn.active {
+  background:   hsla(185, 60%, 65%, 0.12);
+  color:        var(--cyan);
+  border-color: var(--border-active);
+}
+
+.nexus-nav-btn.active::after {
+  content:    '';
+  position:   absolute;
+  bottom:     -1px;
+  left:       20%;
+  width:      60%;
+  height:     2px;
+  background: var(--cyan);
+  border-radius: 99px;
+  box-shadow: 0 0 8px var(--cyan-glow);
+}
+
+.nexus-nav-icon {
+  font-size:  15px;
+  opacity:    0.85;
+}
+
+.nav-badge {
+  min-width:    17px;
+  height:       17px;
+  padding:      0 4px;
+  border-radius:99px;
+  background:   var(--yellow);
+  color:        var(--shale-darkest);
+  font-size:    var(--font-xs);
+  font-weight:  700;
+  line-height:  17px;
+  text-align:   center;
+}
+
+.nexus-header-trail {
+  display:     flex;
+  align-items: center;
+  gap:         10px;
+  flex-shrink: 0;
+}
+
+/* -- Status indicators -- */
+.status-dot {
+  width:         8px;
+  height:        8px;
+  border-radius: 50%;
+  background:    var(--shale-mid);
+  position:      relative;
+}
+
+.status-dot.online  { background: var(--silgreen); animation: pulse-green 2.5s infinite; }
+.status-dot.syncing { background: var(--cyan);     animation: spin-dot 1.2s linear infinite; }
+.status-dot.warning { background: var(--yellow);   animation: pulse-yellow 2s infinite; }
+.status-dot.error   { background: hsla(4, 80%, 65%, 1); }
+
+@keyframes pulse-green {
+  0%,100% { box-shadow: 0 0 0 0 var(--silgreen-glow); }
+  50%      { box-shadow: 0 0 0 5px transparent; }
+}
+@keyframes pulse-yellow {
+  0%,100% { box-shadow: 0 0 0 0 var(--yellow-glow); }
+  50%      { box-shadow: 0 0 0 5px transparent; }
+}
+@keyframes spin-dot {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* -- Sidebars -- */
+.nexus-sidebar {
+  display:        flex;
+  flex-direction: column;
+  background:     var(--surface-raised);
+  border-right:   1px solid var(--border-subtle);
+  overflow:       hidden;
+  transition:     width var(--dur-slow) var(--ease-smooth);
+}
+
+.nexus-sidebar.right {
+  border-right:  none;
+  border-left:   1px solid var(--border-subtle);
+}
+
+.sidebar-section-title {
+  font-size:     var(--font-xs);
+  font-weight:   600;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:         var(--text-muted);
+  padding:       16px 16px 8px;
+}
+
+.sidebar-item {
+  display:        flex;
+  align-items:    center;
+  gap:            9px;
+  padding:        8px 14px;
+  border-radius:  var(--radius-sm);
+  margin:         1px 8px;
+  cursor:         pointer;
+  font-size:      var(--font-sm);
+  color:          var(--text-secondary);
+  transition:     all var(--dur-fast) var(--ease-smooth);
+  border:         1px solid transparent;
+}
+
+.sidebar-item:hover {
+  background: var(--surface-glass);
+  color:      var(--text-primary);
+}
+
+.sidebar-item.active {
+  background:   hsla(185, 60%, 65%, 0.1);
+  color:        var(--cyan);
+  border-color: hsla(185, 60%, 65%, 0.2);
+}
+
+.sidebar-item-icon { font-size: 14px; flex-shrink: 0; }
+
+.sidebar-item-meta {
+  margin-left: auto;
+  font-size:   var(--font-xs);
+  color:       var(--text-muted);
+}
+
+/* -- Main content -- */
+.nexus-main {
+  grid-area:      main;
+  overflow:       hidden;
+  position:       relative;
+  background:     var(--surface-base);
+}
+
+.nexus-panel {
+  position:    absolute;
+  inset:       0;
+  overflow-y:  auto;
+  padding:     24px;
+  display:     none;
+  flex-direction: column;
+  gap:         20px;
+  animation:   panel-in var(--dur-normal) var(--ease-smooth);
+}
+
+.nexus-panel.active {
+  display: flex;
+}
+
+@keyframes panel-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* -- Footer -- */
+.nexus-footer {
+  grid-area:   footer;
+  display:     flex;
+  align-items: center;
+  gap:         16px;
+  padding:     0 20px;
+  background:  hsla(210, 22%, 11%, 0.92);
+  border-top:  1px solid var(--border-subtle);
+  font-size:   var(--font-xs);
+  color:       var(--text-muted);
+}
+
+.footer-tabs {
+  display:     flex;
+  align-items: center;
+  gap:         4px;
+  flex:        1;
+}
+
+.footer-tab {
+  padding:      4px 12px;
+  border-radius:var(--radius-sm);
+  background:   transparent;
+  border:       1px solid transparent;
+  color:        var(--text-muted);
+  font-size:    var(--font-xs);
+  cursor:       pointer;
+  transition:   all var(--dur-fast) var(--ease-smooth);
+}
+
+.footer-tab:hover  { background: var(--surface-glass); color: var(--text-secondary); }
+.footer-tab.active { background: hsla(185, 60%, 65%, 0.1); color: var(--cyan); border-color: var(--border-active); }
+
+.footer-status { display: flex; align-items: center; gap: 8px; }
+
+/* =========================================================================
+   4. COMPONENT LIBRARY
+   ========================================================================= */
+
+/* -- Section header -- */
+.section-header {
+  display:       flex;
+  align-items:   baseline;
+  gap:           12px;
+  margin-bottom: 4px;
+}
+
+.section-title {
+  font-size:     var(--font-xl);
+  font-weight:   700;
+  color:         var(--text-primary);
+  letter-spacing:-0.02em;
+}
+
+.section-subtitle {
+  font-size:  var(--font-sm);
+  color:      var(--text-muted);
+  flex:       1;
+}
+
+/* -- KPI / stat cards -- */
+.stat-grid {
+  display:               grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap:                   14px;
+}
+
+.stat-card {
+  background:    var(--surface-raised);
+  border:        1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding:       18px 20px;
+  display:       flex;
+  flex-direction:column;
+  gap:           6px;
+  transition:    all var(--dur-normal) var(--ease-smooth);
+  cursor:        default;
+  position:      relative;
+  overflow:      hidden;
+}
+
+.stat-card::before {
+  content:  '';
+  position: absolute;
+  top:      0;
+  left:     0;
+  right:    0;
+  height:   2px;
+  background: linear-gradient(90deg, transparent, var(--accent-color, var(--cyan)), transparent);
+  opacity:  0;
+  transition: opacity var(--dur-normal) var(--ease-smooth);
+}
+
+.stat-card:hover { border-color: var(--border-active); transform: translateY(-2px); box-shadow: var(--shadow-md); }
+.stat-card:hover::before { opacity: 1; }
+
+.stat-card.cyan    { --accent-color: var(--cyan); }
+.stat-card.yellow  { --accent-color: var(--yellow); }
+.stat-card.green   { --accent-color: var(--silgreen); }
+.stat-card.shale   { --accent-color: var(--shale-mid); }
+
+.stat-value {
+  font-size:   var(--font-2xl);
+  font-weight: 800;
+  color:       var(--text-primary);
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.stat-value.cyan   { color: var(--cyan); }
+.stat-value.yellow { color: var(--yellow); }
+.stat-value.green  { color: var(--silgreen); }
+
+.stat-label {
+  font-size:  var(--font-sm);
+  color:      var(--text-muted);
+  font-weight:500;
+}
+
+.stat-delta {
+  font-size:   var(--font-xs);
+  font-weight: 600;
+  display:     flex;
+  align-items: center;
+  gap:         3px;
+}
+
+.stat-delta.up   { color: var(--silgreen); }
+.stat-delta.down { color: hsla(4, 70%, 65%, 1); }
+
+.stat-sparkline {
+  height:   32px;
+  margin-top: 6px;
+  opacity:  0.6;
+}
+
+/* -- Cards -- */
+.card {
+  background:    var(--surface-raised);
+  border:        1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding:       18px;
+  transition:    all var(--dur-normal) var(--ease-smooth);
+}
+
+.card:hover { border-color: var(--border-active); }
+
+.card-header {
+  display:        flex;
+  align-items:    center;
+  gap:            10px;
+  margin-bottom:  14px;
+}
+
+.card-title {
+  font-size:  var(--font-md);
+  font-weight:700;
+  color:      var(--text-primary);
+  flex:       1;
+}
+
+.card-actions { display: flex; gap: 6px; }
+
+/* -- Buttons -- */
+.btn {
+  display:        inline-flex;
+  align-items:    center;
+  gap:            7px;
+  padding:        7px 16px;
+  border:         1px solid transparent;
+  border-radius:  var(--radius-md);
+  font-size:      var(--font-sm);
+  font-weight:    600;
+  cursor:         pointer;
+  transition:     all var(--dur-fast) var(--ease-smooth);
+  white-space:    nowrap;
+  user-select:    none;
+}
+
+.btn:active { transform: scale(0.97); }
+
+.btn-primary {
+  background:   var(--cyan);
+  color:        var(--shale-darkest);
+  border-color: transparent;
+  box-shadow:   0 0 0 0 var(--cyan-glow);
+}
+
+.btn-primary:hover {
+  background:  var(--cyan-light);
+  box-shadow:  0 0 14px var(--cyan-glow);
+}
+
+.btn-secondary {
+  background:   var(--surface-overlay);
+  color:        var(--text-primary);
+  border-color: var(--border-subtle);
+}
+
+.btn-secondary:hover {
+  border-color: var(--border-active);
+  background:   var(--surface-glass);
+}
+
+.btn-yellow {
+  background:   var(--yellow);
+  color:        var(--shale-darkest);
+}
+
+.btn-yellow:hover {
+  background:  var(--yellow-light);
+  box-shadow:  0 0 14px var(--yellow-glow);
+}
+
+.btn-green {
+  background:   var(--silgreen);
+  color:        var(--shale-darkest);
+}
+
+.btn-green:hover {
+  background:  var(--silgreen-light);
+  box-shadow:  0 0 14px var(--silgreen-glow);
+}
+
+.btn-ghost {
+  background: transparent;
+  color:      var(--text-secondary);
+}
+
+.btn-ghost:hover { background: var(--surface-glass); color: var(--text-primary); }
+
+.btn-danger {
+  background:  hsla(4, 65%, 55%, 1);
+  color:       white;
+}
+
+.btn-sm { padding: 4px 10px; font-size: var(--font-xs); }
+.btn-lg { padding: 10px 22px; font-size: var(--font-md); }
+.btn-icon { padding: 6px 8px; }
+
+.btn:disabled { opacity: 0.4; cursor: not-allowed; pointer-events: none; }
+
+/* -- Badges -- */
+.badge {
+  display:       inline-flex;
+  align-items:   center;
+  gap:           4px;
+  padding:       2px 8px;
+  border-radius: 99px;
+  font-size:     var(--font-xs);
+  font-weight:   600;
+  border:        1px solid transparent;
+}
+
+.badge-cyan   { background: hsla(185,60%,72%,.15); color: var(--cyan);     border-color: hsla(185,60%,72%,.25); }
+.badge-yellow { background: hsla(46,90%,76%,.15);  color: var(--yellow);   border-color: hsla(46,90%,76%,.25); }
+.badge-green  { background: hsla(142,48%,72%,.15); color: var(--silgreen); border-color: hsla(142,48%,72%,.25); }
+.badge-shale  { background: hsla(210,18%,38%,.3);  color: var(--shale-light); border-color: var(--border-subtle); }
+.badge-danger { background: hsla(4,65%,55%,.15);   color: hsla(4,80%,72%,1); }
+
+/* -- Progress bars -- */
+.progress-bar {
+  height:        6px;
+  background:    var(--surface-overlay);
+  border-radius: 99px;
+  overflow:      hidden;
+}
+
+.progress-fill {
+  height:        100%;
+  border-radius: 99px;
+  background:    linear-gradient(90deg, var(--cyan-dark) 0%, var(--cyan) 100%);
+  transition:    width var(--dur-slow) var(--ease-smooth);
+  box-shadow:    0 0 8px var(--cyan-glow);
+}
+
+.progress-fill.yellow { background: linear-gradient(90deg, var(--yellow-dark) 0%, var(--yellow) 100%); box-shadow: 0 0 8px var(--yellow-glow); }
+.progress-fill.green  { background: linear-gradient(90deg, var(--silgreen-dark) 0%, var(--silgreen) 100%); box-shadow: 0 0 8px var(--silgreen-glow); }
+
+/* -- Inputs -- */
+.input-field {
+  width:         100%;
+  padding:       8px 12px;
+  background:    var(--surface-overlay);
+  border:        1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color:         var(--text-primary);
+  font-size:     var(--font-sm);
+  font-family:   var(--font-sans);
+  transition:    border-color var(--dur-fast) var(--ease-smooth), box-shadow var(--dur-fast) var(--ease-smooth);
+  outline:       none;
+}
+
+.input-field:focus {
+  border-color: var(--cyan);
+  box-shadow:   0 0 0 3px hsla(185, 60%, 65%, 0.15);
+}
+
+.input-field::placeholder { color: var(--text-muted); }
+
+.input-group {
+  display:       flex;
+  flex-direction:column;
+  gap:           5px;
+}
+
+.input-label {
+  font-size:  var(--font-xs);
+  font-weight:600;
+  color:      var(--text-secondary);
+  letter-spacing: 0.04em;
+}
+
+/* -- Tables -- */
+.data-table {
+  width:          100%;
+  border-collapse:separate;
+  border-spacing: 0;
+  font-size:      var(--font-sm);
+}
+
+.data-table th {
+  padding:        10px 14px;
+  text-align:     left;
+  font-size:      var(--font-xs);
+  font-weight:    600;
+  color:          var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-bottom:  1px solid var(--border-subtle);
+  white-space:    nowrap;
+}
+
+.data-table td {
+  padding:        11px 14px;
+  border-bottom:  1px solid hsla(210, 22%, 20%, 0.6);
+  color:          var(--text-secondary);
+  vertical-align: middle;
+}
+
+.data-table tbody tr {
+  transition: background var(--dur-fast) var(--ease-smooth);
+}
+
+.data-table tbody tr:hover td { background: var(--surface-glass); color: var(--text-primary); }
+
+/* -- Tag chips -- */
+.tag {
+  display:       inline-flex;
+  align-items:   center;
+  gap:           4px;
+  padding:       2px 9px;
+  border-radius: var(--radius-sm);
+  font-size:     var(--font-xs);
+  font-weight:   500;
+  background:    var(--surface-overlay);
+  color:         var(--text-secondary);
+  border:        1px solid var(--border-subtle);
+  cursor:        default;
+}
+
+/* -- Activity feed -- */
+.activity-item {
+  display:        flex;
+  gap:            10px;
+  padding:        10px 0;
+  border-bottom:  1px solid var(--border-subtle);
+  font-size:      var(--font-sm);
+}
+
+.activity-dot {
+  width:         8px;
+  height:        8px;
+  border-radius: 50%;
+  background:    var(--cyan);
+  flex-shrink:   0;
+  margin-top:    5px;
+}
+
+.activity-dot.yellow { background: var(--yellow); }
+.activity-dot.green  { background: var(--silgreen); }
+
+.activity-content { flex: 1; }
+.activity-time    { font-size: var(--font-xs); color: var(--text-muted); }
+
+/* -- Integration status card -- */
+.integration-card {
+  display:        flex;
+  align-items:    center;
+  gap:            12px;
+  padding:        12px 16px;
+  background:     var(--surface-raised);
+  border:         1px solid var(--border-subtle);
+  border-radius:  var(--radius-md);
+  font-size:      var(--font-sm);
+  transition:     all var(--dur-normal) var(--ease-smooth);
+  cursor:         pointer;
+}
+
+.integration-card:hover { border-color: var(--border-active); }
+.integration-card.connected { border-color: hsla(142,48%,60%,.35); }
+
+.integration-icon {
+  width:         36px;
+  height:        36px;
+  border-radius: var(--radius-sm);
+  display:       flex;
+  align-items:   center;
+  justify-content: center;
+  font-size:     18px;
+  background:    var(--surface-overlay);
+  flex-shrink:   0;
+}
+
+.integration-info { flex: 1; }
+.integration-name { font-weight: 600; color: var(--text-primary); }
+.integration-desc { font-size: var(--font-xs); color: var(--text-muted); margin-top: 1px; }
+
+/* -- Modal -- */
+.modal-backdrop {
+  position:        fixed;
+  inset:           0;
+  background:      hsla(210, 30%, 5%, 0.75);
+  backdrop-filter: blur(4px);
+  z-index:         var(--z-modal);
+  display:         flex;
+  align-items:     center;
+  justify-content: center;
+  animation:       fade-in var(--dur-fast) var(--ease-smooth);
+}
+
+.modal {
+  background:    var(--surface-raised);
+  border:        1px solid var(--border-active);
+  border-radius: var(--radius-xl);
+  padding:       28px;
+  max-width:     520px;
+  width:         90vw;
+  box-shadow:    var(--shadow-glow);
+  animation:     modal-in var(--dur-normal) var(--ease-spring);
+}
+
+@keyframes modal-in {
+  from { opacity: 0; transform: scale(0.94) translateY(10px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.modal-header {
+  display:       flex;
+  align-items:   center;
+  gap:           12px;
+  margin-bottom: 18px;
+}
+
+.modal-title {
+  font-size:  var(--font-lg);
+  font-weight:700;
+  color:      var(--text-primary);
+  flex:       1;
+}
+
+/* -- Toast notifications -- */
+.toast-container {
+  position:       fixed;
+  bottom:         72px;
+  right:          24px;
+  z-index:        var(--z-toast);
+  display:        flex;
+  flex-direction: column;
+  gap:            8px;
+  pointer-events: none;
+}
+
+.toast {
+  display:        flex;
+  align-items:    center;
+  gap:            10px;
+  padding:        12px 16px;
+  background:     var(--surface-overlay);
+  border:         1px solid var(--border-subtle);
+  border-radius:  var(--radius-md);
+  box-shadow:     var(--shadow-lg);
+  font-size:      var(--font-sm);
+  pointer-events: auto;
+  animation:      toast-in var(--dur-normal) var(--ease-spring);
+  max-width:      340px;
+}
+
+.toast.success { border-color: hsla(142,48%,60%,.4); background: hsla(142,48%,15%,.95); }
+.toast.error   { border-color: hsla(4,65%,60%,.4);   background: hsla(4,65%,15%,.95); }
+.toast.info    { border-color: hsla(185,60%,60%,.4);  background: hsla(185,60%,15%,.95); }
+.toast.warn    { border-color: hsla(46,90%,65%,.4);   background: hsla(46,90%,15%,.95); }
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateX(20px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+/* -- Dividers -- */
+.divider {
+  height:  1px;
+  background: var(--border-subtle);
+  margin: 4px 0;
+}
+
+/* =========================================================================
+   5. MODULE-SPECIFIC STYLES
+   ========================================================================= */
+
+/* -- Projects module -- */
+.project-row {
+  display:        grid;
+  grid-template-columns: auto 1fr auto auto auto;
+  align-items:    center;
+  gap:            12px;
+  padding:        13px 16px;
+  background:     var(--surface-raised);
+  border:         1px solid var(--border-subtle);
+  border-radius:  var(--radius-md);
+  transition:     all var(--dur-normal) var(--ease-smooth);
+  cursor:         pointer;
+}
+
+.project-row:hover {
+  border-color: var(--border-active);
+  background:   var(--surface-overlay);
+  box-shadow:   var(--shadow-sm);
+}
+
+.project-color-dot {
+  width:         10px;
+  height:        10px;
+  border-radius: 50%;
+  flex-shrink:   0;
+}
+
+.project-name {
+  font-weight: 600;
+  color:       var(--text-primary);
+  font-size:   var(--font-sm);
+}
+
+.project-meta {
+  font-size: var(--font-xs);
+  color:     var(--text-muted);
+  margin-top:2px;
+}
+
+.project-progress { min-width: 100px; }
+
+/* -- Task board / kanban -- */
+.kanban-board {
+  display:  flex;
+  gap:      16px;
+  overflow-x:auto;
+  padding-bottom: 8px;
+  min-height: 400px;
+}
+
+.kanban-col {
+  min-width: 260px;
+  display:   flex;
+  flex-direction: column;
+  gap:       8px;
+}
+
+.kanban-col-header {
+  display:       flex;
+  align-items:   center;
+  gap:           8px;
+  padding:       8px 12px;
+  border-radius: var(--radius-md);
+  background:    var(--surface-raised);
+  border:        1px solid var(--border-subtle);
+  font-size:     var(--font-sm);
+  font-weight:   600;
+  color:         var(--text-secondary);
+}
+
+.kanban-count {
+  margin-left: auto;
+  background:  var(--surface-overlay);
+  padding:     1px 7px;
+  border-radius:99px;
+  font-size:   var(--font-xs);
+  color:       var(--text-muted);
+}
+
+.task-card {
+  background:    var(--surface-raised);
+  border:        1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding:       12px 14px;
+  cursor:        grab;
+  transition:    all var(--dur-normal) var(--ease-smooth);
+  font-size:     var(--font-sm);
+}
+
+.task-card:hover {
+  border-color: var(--border-active);
+  box-shadow:   var(--shadow-sm);
+  transform:    translateY(-1px);
+}
+
+.task-card:active { cursor: grabbing; }
+
+.task-title {
+  font-weight: 600;
+  color:       var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.task-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; }
+
+/* -- Dashboard gauge -- */
+.gauge-ring {
+  position: relative;
+  display:  inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.gauge-value {
+  position:    absolute;
+  font-size:   var(--font-xl);
+  font-weight: 800;
+  color:       var(--text-primary);
+  letter-spacing: -0.03em;
+}
+
+/* -- Lab/build log -- */
+.log-terminal {
+  font-family:    var(--font-mono);
+  font-size:      var(--font-xs);
+  background:     var(--shale-darkest);
+  border:         1px solid var(--border-subtle);
+  border-radius:  var(--radius-md);
+  padding:        14px 16px;
+  overflow-y:     auto;
+  max-height:     340px;
+  line-height:    1.7;
+}
+
+.log-line           { color: var(--text-secondary); }
+.log-line.success   { color: var(--silgreen); }
+.log-line.error     { color: hsla(4,80%,70%,1); }
+.log-line.warn      { color: var(--yellow); }
+.log-line.info      { color: var(--cyan); }
+.log-line.timestamp { color: var(--shale-mid); }
+
+/* -- Map overlay -- */
+.map-container {
+  width:         100%;
+  height:        100%;
+  border-radius: var(--radius-lg);
+  overflow:      hidden;
+  position:      relative;
+  background:    var(--shale-darkest);
+}
+
+.map-controls {
+  position:      absolute;
+  top:           14px;
+  right:         14px;
+  display:       flex;
+  flex-direction:column;
+  gap:           6px;
+  z-index:       10;
+}
+
+/* =========================================================================
+   6. ANIMATIONS & TRANSITIONS
+   ========================================================================= */
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes shimmer {
+  0%   { background-position: -200% center; }
+  100% { background-position:  200% center; }
+}
+
+/* Skeleton loader */
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--surface-overlay) 25%,
+    var(--surface-glass) 50%,
+    var(--surface-overlay) 75%
+  );
+  background-size: 200% 100%;
+  animation:       shimmer 1.5s ease-in-out infinite;
+  border-radius:   var(--radius-sm);
+}
+
+/* =========================================================================
+   7. REACTIVE STATES
+   ========================================================================= */
+
+/* Loading overlay */
+.loading-overlay {
+  position:        absolute;
+  inset:           0;
+  background:      hsla(210, 22%, 10%, 0.7);
+  backdrop-filter: blur(2px);
+  display:         flex;
+  align-items:     center;
+  justify-content: center;
+  z-index:         50;
+  border-radius:   inherit;
+}
+
+.spinner {
+  width:         36px;
+  height:        36px;
+  border:        3px solid var(--border-subtle);
+  border-top-color: var(--cyan);
+  border-radius: 50%;
+  animation:     spin var(--dur-slow) linear infinite;
+}
+
+.spinner-sm { width: 20px; height: 20px; border-width: 2px; }
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Offline banner */
+.offline-banner {
+  display:        flex;
+  align-items:    center;
+  gap:            10px;
+  padding:        8px 16px;
+  background:     hsla(46, 90%, 50%, 0.15);
+  border-bottom:  1px solid hsla(46, 90%, 65%, 0.3);
+  color:          var(--yellow);
+  font-size:      var(--font-sm);
+  font-weight:    500;
+  animation:      fade-in var(--dur-fast) var(--ease-smooth);
+}
+
+/* Empty state */
+.empty-state {
+  display:        flex;
+  flex-direction: column;
+  align-items:    center;
+  justify-content:center;
+  gap:            12px;
+  padding:        48px 24px;
+  text-align:     center;
+  color:          var(--text-muted);
+}
+
+.empty-state-icon { font-size: 40px; opacity: 0.5; }
+.empty-state-title { font-size: var(--font-md); font-weight: 600; color: var(--text-secondary); }
+.empty-state-body  { font-size: var(--font-sm); max-width: 280px; line-height: 1.6; }
+
+/* =========================================================================
+   8. RESPONSIVE BREAKPOINTS
+   ========================================================================= */
+
+@media (max-width: 1100px) {
+  .nexus-shell {
+    grid-template-columns: var(--sidebar-w-sm) 1fr 0px;
+    grid-template-areas:
+      "header  header  header"
+      "left    main    main"
+      "footer  footer  footer";
+  }
+
+  .nexus-sidebar.right { display: none; }
+}
+
+@media (max-width: 720px) {
+  .nexus-shell {
+    grid-template-columns: 0px 1fr 0px;
+    grid-template-areas:
+      "header  header  header"
+      "main    main    main"
+      "footer  footer  footer";
+  }
+
+  .nexus-sidebar { display: none; }
+  .nexus-panel   { padding: 16px; }
+  .stat-grid     { grid-template-columns: 1fr 1fr; }
+}
+
+/* =========================================================================
+   9. UTILITY CLASSES
+   ========================================================================= */
+
+.flex        { display: flex; }
+.flex-col    { display: flex; flex-direction: column; }
+.items-center{ align-items: center; }
+.items-start { align-items: flex-start; }
+.justify-between { justify-content: space-between; }
+.justify-end     { justify-content: flex-end; }
+.gap-4  { gap: 4px; }
+.gap-8  { gap: 8px; }
+.gap-12 { gap: 12px; }
+.gap-16 { gap: 16px; }
+.gap-20 { gap: 20px; }
+.flex-1 { flex: 1; }
+.w-full { width: 100%; }
+.text-xs   { font-size: var(--font-xs); }
+.text-sm   { font-size: var(--font-sm); }
+.text-muted{ color: var(--text-muted); }
+.text-cyan { color: var(--cyan); }
+.text-yellow { color: var(--yellow); }
+.text-green  { color: var(--silgreen); }
+.font-semibold { font-weight: 600; }
+.font-bold     { font-weight: 700; }
+.truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mt-4  { margin-top: 4px; }
+.mt-8  { margin-top: 8px; }
+.mt-12 { margin-top: 12px; }
+.mt-16 { margin-top: 16px; }
+.mb-8  { margin-bottom: 8px; }
+.mb-16 { margin-bottom: 16px; }
+.p-0 { padding: 0; }
+.rounded { border-radius: var(--radius-md); }
+.overflow-hidden { overflow: hidden; }
+.overflow-auto   { overflow: auto; }
+.relative { position: relative; }
+.cursor-pointer { cursor: pointer; }
+.opacity-60 { opacity: 0.6; }
+.sr-only {
+  position: absolute;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}

--- a/nexus/nexus.html
+++ b/nexus/nexus.html
@@ -1,0 +1,711 @@
+<!DOCTYPE html>
+<html lang="en" data-nexus-version="1.0.0" data-app="javelin">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Javelin — Nexus</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="nexus.css" />
+
+  <style>
+    body { visibility: hidden; }
+    body.nexus-ready { visibility: visible; }
+
+    /* Javelin branding overrides */
+    :root {
+      --brand-primary: var(--cyan);
+      --brand-name:    'Javelin';
+    }
+
+    .nexus-logo-mark {
+      background: linear-gradient(135deg, var(--cyan) 0%, var(--yellow) 100%);
+    }
+  </style>
+</head>
+<body>
+
+<div class="nexus-shell" id="nexus-shell">
+
+  <!-- HEADER -->
+  <header class="nexus-header" role="banner">
+    <div class="nexus-logo" title="Javelin Nexus v1.0">
+      <div class="nexus-logo-mark" aria-hidden="true">J</div>
+      <span>Javelin</span>
+    </div>
+
+    <nav class="nexus-nav" role="navigation" aria-label="Module navigation">
+      <button class="nexus-nav-btn active" data-panel="dashboard">
+        <span class="nexus-nav-icon">⬛</span> Dashboard
+      </button>
+      <button class="nexus-nav-btn" data-panel="projects">
+        <span class="nexus-nav-icon">📋</span> Projects
+        <span class="nav-badge" id="badge-projects">0</span>
+      </button>
+      <button class="nexus-nav-btn" data-panel="containers">
+        <span class="nexus-nav-icon">📦</span> Containers
+      </button>
+      <button class="nexus-nav-btn" data-panel="library">
+        <span class="nexus-nav-icon">📚</span> Library
+      </button>
+      <button class="nexus-nav-btn" data-panel="labs">
+        <span class="nexus-nav-icon">🧪</span> Labs
+      </button>
+      <button class="nexus-nav-btn" data-panel="networks">
+        <span class="nexus-nav-icon">🌐</span> Networks
+      </button>
+      <button class="nexus-nav-btn" data-panel="media">
+        <span class="nexus-nav-icon">🎬</span> Media
+      </button>
+      <button class="nexus-nav-btn" data-panel="maps">
+        <span class="nexus-nav-icon">🗺</span> Maps
+      </button>
+      <button class="nexus-nav-btn" data-panel="integrations">
+        <span class="nexus-nav-icon">🔗</span> Integrations
+      </button>
+      <button class="nexus-nav-btn" data-panel="governance">
+        <span class="nexus-nav-icon">🔒</span> Governance
+      </button>
+    </nav>
+
+    <div class="nexus-header-trail">
+      <div class="flex items-center gap-8">
+        <div class="status-dot online" id="status-connectivity"></div>
+        <span class="text-xs text-muted" id="status-label">Online</span>
+      </div>
+      <div class="badge badge-cyan" id="user-badge">
+        <span id="user-display">Guest</span>
+      </div>
+      <button class="btn btn-ghost btn-sm" id="btn-logout" title="Logout">↩ Logout</button>
+      <button class="btn btn-ghost btn-sm btn-icon" data-panel="settings">⚙</button>
+    </div>
+  </header>
+
+  <!-- LEFT SIDEBAR -->
+  <aside class="nexus-sidebar">
+    <div class="sidebar-section-title">Quick Actions</div>
+    <button class="sidebar-item" id="btn-new-project">
+      <span class="sidebar-item-icon">＋</span> New Project
+    </button>
+    <button class="sidebar-item" id="btn-new-container">
+      <span class="sidebar-item-icon">📦</span> New Container
+    </button>
+    <button class="sidebar-item" id="btn-sync-all">
+      <span class="sidebar-item-icon">↻</span> Sync All
+    </button>
+
+    <div class="divider" style="margin: 8px 16px;"></div>
+
+    <div class="sidebar-section-title">Containers</div>
+    <div id="container-tree" style="flex:1; overflow-y:auto;">
+      <!-- Populated by container module list -->
+      <div class="sidebar-item" data-container="DeckBoss">
+        <span class="sidebar-item-icon">🃏</span> DeckBoss
+        <span class="badge badge-shale sidebar-item-meta">Idle</span>
+      </div>
+      <div class="sidebar-item" data-container="ZSkipper">
+        <span class="sidebar-item-icon">⛵</span> ZSkipper
+        <span class="badge badge-shale sidebar-item-meta">Idle</span>
+      </div>
+      <div class="sidebar-item" data-container="DataFarm">
+        <span class="sidebar-item-icon">🌾</span> DataFarm
+        <span class="badge badge-shale sidebar-item-meta">Idle</span>
+      </div>
+      <div class="sidebar-item" data-container="Captain">
+        <span class="sidebar-item-icon">⚓</span> Captain
+        <span class="badge badge-shale sidebar-item-meta">Idle</span>
+      </div>
+      <div class="sidebar-item" data-container="Maps">
+        <span class="sidebar-item-icon">🗺</span> Maps
+        <span class="badge badge-shale sidebar-item-meta">Idle</span>
+      </div>
+    </div>
+
+    <div class="divider" style="margin: 8px 16px;"></div>
+
+    <div style="padding:12px 16px;">
+      <div class="text-xs text-muted" style="margin-bottom:4px;">Javelin Instance</div>
+      <div class="flex items-center gap-8 text-xs mt-4">
+        <span class="badge badge-green" id="auth-status-badge">Authenticated</span>
+      </div>
+    </div>
+  </aside>
+
+  <!-- MAIN CONTENT -->
+  <main class="nexus-main" role="main">
+
+    <div class="offline-banner" id="offline-banner" style="display:none;">
+      ⚠ Offline — serving from local cache. Changes sync on reconnect.
+    </div>
+
+    <!-- Dashboard panel -->
+    <section class="nexus-panel active" id="panel-dashboard">
+      <div class="section-header">
+        <h1 class="section-title">Dashboard</h1>
+        <span class="section-subtitle">Javelin ecosystem overview</span>
+        <button class="btn btn-primary btn-sm" data-panel="projects">Projects →</button>
+      </div>
+
+      <div class="stat-grid">
+        <div class="stat-card cyan">
+          <div class="stat-value cyan" id="stat-projects">0</div>
+          <div class="stat-label">Active Projects</div>
+        </div>
+        <div class="stat-card yellow">
+          <div class="stat-value yellow" id="stat-containers">5</div>
+          <div class="stat-label">Containers Available</div>
+        </div>
+        <div class="stat-card green">
+          <div class="stat-value green" id="stat-tasks">0</div>
+          <div class="stat-label">Open Tasks</div>
+        </div>
+        <div class="stat-card shale">
+          <div class="stat-value" id="stat-user">—</div>
+          <div class="stat-label">Logged In As</div>
+        </div>
+      </div>
+
+      <div class="flex gap-16" style="flex:1; min-height:0; overflow:hidden;">
+        <div class="card flex-col" style="flex:1.5; overflow:hidden;">
+          <div class="card-header">
+            <span class="card-title">Recent Projects</span>
+            <button class="btn btn-ghost btn-sm" data-panel="projects">View all →</button>
+          </div>
+          <div id="recent-projects" style="overflow-y:auto; flex:1;">
+            <div class="empty-state" style="padding:24px 0;">
+              <div class="empty-state-icon">📋</div>
+              <div class="empty-state-body">No projects yet.</div>
+            </div>
+          </div>
+        </div>
+
+        <div class="card flex-col" style="flex:1; overflow:hidden;">
+          <div class="card-header">
+            <span class="card-title">Activity</span>
+            <div class="status-dot syncing"></div>
+          </div>
+          <div id="activity-feed" style="overflow-y:auto; flex:1;">
+            <div class="empty-state" style="padding:24px 0;">
+              <div class="empty-state-body">Activity will appear here.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Projects panel -->
+    <section class="nexus-panel" id="panel-projects">
+      <div class="section-header">
+        <h1 class="section-title">Projects</h1>
+        <span class="section-subtitle" id="projects-count-label">—</span>
+        <button class="btn btn-primary btn-sm" id="btn-new-project-main">＋ New Project</button>
+      </div>
+
+      <div class="flex gap-8 items-center">
+        <input class="input-field" id="project-search" placeholder="Search projects…" style="max-width:280px;" />
+        <span class="badge badge-cyan" data-filter="all">All</span>
+        <span class="badge badge-shale" data-filter="active">Active</span>
+        <span class="badge badge-shale" data-filter="completed">Done</span>
+      </div>
+
+      <div id="project-list" style="display:flex; flex-direction:column; gap:8px; overflow-y:auto; flex:1;">
+        <div class="empty-state">
+          <div class="empty-state-icon">📋</div>
+          <div class="empty-state-title">No projects yet</div>
+          <div class="empty-state-body">Create your first project to start organizing your Javelin containers and tasks.</div>
+          <button class="btn btn-primary" id="btn-create-first-project">＋ Create Project</button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Containers panel (Javelin-specific) -->
+    <section class="nexus-panel" id="panel-containers">
+      <div class="section-header">
+        <h1 class="section-title">Containers</h1>
+        <span class="section-subtitle">Modular application containers</span>
+        <button class="btn btn-primary btn-sm" id="btn-new-container-main">＋ Deploy Container</button>
+      </div>
+
+      <div style="display:grid; grid-template-columns:repeat(auto-fill,minmax(280px,1fr)); gap:14px;">
+        <!-- DeckBoss -->
+        <div class="card">
+          <div class="card-header">
+            <span style="font-size:24px;">🃏</span>
+            <span class="card-title">DeckBoss</span>
+            <span class="badge badge-shale" id="status-deckboss">Idle</span>
+          </div>
+          <p class="text-xs text-muted" style="margin-bottom:12px;">Deck and card management container. Manages project workflows and card-based task organization.</p>
+          <div class="flex gap-8">
+            <button class="btn btn-green btn-sm" data-start-container="DeckBoss">▶ Start</button>
+            <button class="btn btn-secondary btn-sm" data-config-container="DeckBoss">Config</button>
+            <button class="btn btn-secondary btn-sm" data-logs-container="DeckBoss">Logs</button>
+          </div>
+        </div>
+
+        <!-- ZSkipper -->
+        <div class="card">
+          <div class="card-header">
+            <span style="font-size:24px;">⛵</span>
+            <span class="card-title">ZSkipper</span>
+            <span class="badge badge-shale" id="status-zskipper">Idle</span>
+          </div>
+          <p class="text-xs text-muted" style="margin-bottom:12px;">Navigation and routing container. Manages data flows between containers and external systems.</p>
+          <div class="flex gap-8">
+            <button class="btn btn-green btn-sm" data-start-container="ZSkipper">▶ Start</button>
+            <button class="btn btn-secondary btn-sm" data-config-container="ZSkipper">Config</button>
+            <button class="btn btn-secondary btn-sm" data-logs-container="ZSkipper">Logs</button>
+          </div>
+        </div>
+
+        <!-- DataFarm -->
+        <div class="card">
+          <div class="card-header">
+            <span style="font-size:24px;">🌾</span>
+            <span class="card-title">DataFarm</span>
+            <span class="badge badge-shale" id="status-datafarm">Idle</span>
+          </div>
+          <p class="text-xs text-muted" style="margin-bottom:12px;">Data ingestion and processing container. Harvests, cleans, and stores data from scraping pipelines.</p>
+          <div class="flex gap-8">
+            <button class="btn btn-green btn-sm" data-start-container="DataFarm">▶ Start</button>
+            <button class="btn btn-secondary btn-sm" data-config-container="DataFarm">Config</button>
+            <button class="btn btn-secondary btn-sm" data-logs-container="DataFarm">Logs</button>
+          </div>
+        </div>
+
+        <!-- Captain -->
+        <div class="card">
+          <div class="card-header">
+            <span style="font-size:24px;">⚓</span>
+            <span class="card-title">Captain</span>
+            <span class="badge badge-shale" id="status-captain">Idle</span>
+          </div>
+          <p class="text-xs text-muted" style="margin-bottom:12px;">Container orchestration and health monitoring. Manages the lifecycle of all Javelin containers.</p>
+          <div class="flex gap-8">
+            <button class="btn btn-green btn-sm" data-start-container="Captain">▶ Start</button>
+            <button class="btn btn-secondary btn-sm" data-config-container="Captain">Config</button>
+            <button class="btn btn-secondary btn-sm" data-logs-container="Captain">Logs</button>
+          </div>
+        </div>
+
+        <!-- OpenContainer -->
+        <div class="card" style="border-style:dashed;">
+          <div class="card-header">
+            <span style="font-size:24px;">📦</span>
+            <span class="card-title">OpenContainer</span>
+            <span class="badge badge-shale">Template</span>
+          </div>
+          <p class="text-xs text-muted" style="margin-bottom:12px;">Base template for new containers. Fork this to create a new modular application for the Javelin ecosystem.</p>
+          <div class="flex gap-8">
+            <button class="btn btn-yellow btn-sm" id="btn-fork-opencontainer">Fork Template</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Container log viewer -->
+      <div class="card" id="container-log-card" style="display:none;">
+        <div class="card-header">
+          <span class="card-title" id="log-container-name">Container Log</span>
+          <button class="btn btn-ghost btn-sm btn-icon" id="btn-close-log">✕</button>
+        </div>
+        <div class="log-terminal" id="container-log" style="height:240px;"></div>
+      </div>
+    </section>
+
+    <!-- Library, Labs, Networks, Media, Maps — same as workstation -->
+    <section class="nexus-panel" id="panel-library">
+      <div class="section-header">
+        <h1 class="section-title">Library</h1>
+        <span class="section-subtitle">Assets, volumes, documents</span>
+        <button class="btn btn-primary btn-sm">＋ Add Resource</button>
+      </div>
+      <div class="card">
+        <div class="empty-state">
+          <div class="empty-state-icon">📚</div>
+          <div class="empty-state-title">Library is empty</div>
+          <div class="empty-state-body">Add volumes and documents to build your library.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nexus-panel" id="panel-labs">
+      <div class="section-header">
+        <h1 class="section-title">Labs</h1>
+        <span class="section-subtitle">Build and run lab scripts</span>
+        <button class="btn btn-green btn-sm">▶ Run</button>
+      </div>
+      <div class="card">
+        <div class="log-terminal" id="lab-log">
+          <div class="log-line info">[nexus:lab] Ready.</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nexus-panel" id="panel-networks">
+      <div class="section-header">
+        <h1 class="section-title">Networks</h1>
+        <span class="section-subtitle">Local and remote topology</span>
+      </div>
+      <div class="stat-grid" style="grid-template-columns: repeat(3, 1fr);">
+        <div class="stat-card cyan"><div class="stat-value cyan">0</div><div class="stat-label">Active</div></div>
+        <div class="stat-card yellow"><div class="stat-value yellow">0</div><div class="stat-label">Pending</div></div>
+        <div class="stat-card green"><div class="stat-value green">0</div><div class="stat-label">Services</div></div>
+      </div>
+    </section>
+
+    <section class="nexus-panel" id="panel-media">
+      <div class="section-header">
+        <h1 class="section-title">Media</h1>
+        <span class="section-subtitle">Sources and streams</span>
+        <button class="btn btn-primary btn-sm">＋ Add Source</button>
+      </div>
+      <div class="card">
+        <div class="empty-state">
+          <div class="empty-state-icon">🎬</div>
+          <div class="empty-state-title">No media sources</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nexus-panel" id="panel-maps">
+      <div class="section-header">
+        <h1 class="section-title">Maps</h1>
+        <span class="section-subtitle">Spatial data and overlays</span>
+      </div>
+      <div class="map-container" style="flex:1; min-height:400px;">
+        <div class="empty-state" style="height:100%;">
+          <div class="empty-state-icon">🗺</div>
+          <div class="empty-state-title">Map viewer — wire a provider to display maps</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Integrations panel -->
+    <section class="nexus-panel" id="panel-integrations">
+      <div class="section-header">
+        <h1 class="section-title">Integrations</h1>
+        <span class="section-subtitle">Connect your external ecosystem</span>
+      </div>
+      <div style="display:grid; grid-template-columns:repeat(auto-fit,minmax(300px,1fr)); gap:14px;">
+        <div class="card" id="config-airtable">
+          <div class="card-header">
+            <span style="font-size:24px;">📊</span>
+            <span class="card-title">Airtable</span>
+            <span class="badge badge-shale" id="airtable-status-badge">Disconnected</span>
+          </div>
+          <div class="input-group"><label class="input-label">API Key</label>
+            <input class="input-field" type="password" id="airtable-api-key" placeholder="key•••••" /></div>
+          <div class="input-group mt-8"><label class="input-label">Base ID</label>
+            <input class="input-field" id="airtable-base-id" placeholder="appXXXXXXXX" /></div>
+          <div class="flex gap-8 mt-12">
+            <button class="btn btn-primary btn-sm" id="btn-connect-airtable">Connect</button>
+            <button class="btn btn-ghost btn-sm" id="btn-sync-airtable-now" style="margin-left:auto;">↻ Sync</button>
+          </div>
+        </div>
+        <div class="card" id="config-ai">
+          <div class="card-header">
+            <span style="font-size:24px;">🤖</span>
+            <span class="card-title">AI (Claude)</span>
+            <span class="badge badge-shale" id="ai-status-badge">Disconnected</span>
+          </div>
+          <div class="input-group"><label class="input-label">Anthropic API Key</label>
+            <input class="input-field" type="password" id="ai-api-key" placeholder="sk-ant-•••" /></div>
+          <div class="input-group mt-8"><label class="input-label">Model</label>
+            <select class="input-field" id="ai-model">
+              <option value="claude-sonnet-4-6">Claude Sonnet 4.6</option>
+              <option value="claude-opus-4-7">Claude Opus 4.7</option>
+            </select>
+          </div>
+          <div class="flex gap-8 mt-12">
+            <button class="btn btn-primary btn-sm" id="btn-connect-ai">Connect</button>
+            <button class="btn btn-yellow btn-sm" id="btn-ai-assist">✨ Ask AI</button>
+          </div>
+        </div>
+        <div class="card" id="config-github">
+          <div class="card-header">
+            <span style="font-size:24px;">⚙</span>
+            <span class="card-title">GitHub</span>
+            <span class="badge badge-shale" id="github-status-badge">Disconnected</span>
+          </div>
+          <div class="input-group"><label class="input-label">Personal Access Token</label>
+            <input class="input-field" type="password" id="github-pat" placeholder="ghp_•••" /></div>
+          <div class="input-group mt-8"><label class="input-label">Default Repo</label>
+            <input class="input-field" id="github-repo" value="jpuskas3/javelin" /></div>
+          <div class="flex gap-8 mt-12">
+            <button class="btn btn-primary btn-sm" id="btn-connect-github">Connect</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Governance panel -->
+    <section class="nexus-panel" id="panel-governance">
+      <div class="section-header">
+        <h1 class="section-title">Governance</h1>
+        <span class="section-subtitle">Owner sovereignty — your machine, your rules</span>
+        <button class="btn btn-primary btn-sm" id="btn-save-policy">Save Policy</button>
+      </div>
+      <div class="flex gap-16" style="flex:1; min-height:0; overflow:hidden;">
+        <div class="card flex-col" style="flex:1;">
+          <div class="card-header"><span class="card-title">Active Policy</span></div>
+          <textarea class="input-field" id="policy-editor"
+            style="flex:1; min-height:280px; font-family:var(--font-mono); font-size:var(--font-xs); resize:none; line-height:1.7;"
+            spellcheck="false"></textarea>
+          <div class="flex gap-8 mt-8">
+            <button class="btn btn-secondary btn-sm" id="btn-reset-policy">Reset</button>
+            <button class="btn btn-secondary btn-sm" id="btn-validate-policy">Validate</button>
+          </div>
+        </div>
+        <div class="card flex-col" style="width:320px; flex-shrink:0; overflow:hidden;">
+          <div class="card-header"><span class="card-title">Audit Log</span></div>
+          <div id="audit-log" class="log-terminal" style="flex:1; min-height:0;">
+            <div class="log-line info">[governance] Ready.</div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Settings panel -->
+    <section class="nexus-panel" id="panel-settings">
+      <div class="section-header">
+        <h1 class="section-title">Settings</h1>
+      </div>
+      <div class="card">
+        <div class="card-header"><span class="card-title">Javelin Instance</span></div>
+        <div class="input-group" style="max-width:360px;">
+          <label class="input-label">Instance Name</label>
+          <input class="input-field" id="settings-instance" placeholder="My Javelin" value="Javelin Workstation" />
+        </div>
+        <div class="flex gap-8 mt-12">
+          <button class="btn btn-primary btn-sm" id="btn-save-settings">Save</button>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- RIGHT SIDEBAR -->
+  <aside class="nexus-sidebar right">
+    <div class="sidebar-section-title">AI Assistant</div>
+    <div style="padding:0 8px; margin-bottom:8px;">
+      <div class="card" style="padding:10px;">
+        <textarea class="input-field" id="ai-quick-input"
+          placeholder="Ask AI about your Javelin containers…"
+          style="min-height:64px; font-size:var(--font-xs); resize:none;"></textarea>
+        <button class="btn btn-yellow btn-sm w-full mt-8" id="btn-ai-quick-ask">✨ Ask</button>
+        <div id="ai-quick-response" class="text-xs text-muted mt-8" style="min-height:32px;"></div>
+      </div>
+    </div>
+
+    <div class="divider" style="margin:4px 16px;"></div>
+
+    <div class="sidebar-section-title">Live Activity</div>
+    <div id="sidebar-activity" style="flex:1; overflow-y:auto; padding:0 8px;">
+      <div class="empty-state" style="padding:20px 8px;">
+        <div class="empty-state-body">No activity yet.</div>
+      </div>
+    </div>
+  </aside>
+
+  <!-- FOOTER -->
+  <footer class="nexus-footer">
+    <div class="footer-tabs">
+      <button class="footer-tab active" data-panel="dashboard">Dashboard</button>
+      <button class="footer-tab" data-panel="projects">Projects</button>
+      <button class="footer-tab" data-panel="containers">Containers</button>
+      <button class="footer-tab" data-panel="labs">Labs</button>
+      <button class="footer-tab" data-panel="integrations">Integrations</button>
+    </div>
+    <div class="footer-status">
+      <div class="status-dot online" id="footer-status-dot"></div>
+      <span id="footer-status-text">Javelin ready</span>
+      <span style="opacity:.3;">|</span>
+      <span class="text-xs text-muted">User: <span id="footer-user">—</span></span>
+      <span style="opacity:.3;">|</span>
+      <span class="text-xs text-muted" id="footer-time">—</span>
+    </div>
+  </footer>
+
+</div><!-- /nexus-shell -->
+
+<div class="toast-container" id="toast-container" aria-live="polite"></div>
+
+<template id="tmpl-modal-new-project">
+  <div class="modal">
+    <div class="modal-header">
+      <span class="modal-title">New Project</span>
+      <button class="btn btn-ghost btn-sm btn-icon modal-close">✕</button>
+    </div>
+    <div style="display:flex; flex-direction:column; gap:10px;">
+      <div class="input-group">
+        <label class="input-label">Project Name</label>
+        <input class="input-field" id="new-project-name" placeholder="Enter project name…" autofocus />
+      </div>
+      <div class="input-group">
+        <label class="input-label">Description</label>
+        <textarea class="input-field" id="new-project-desc" style="min-height:64px;resize:none;" placeholder="What is this project about?"></textarea>
+      </div>
+    </div>
+    <div class="flex gap-8 mt-16">
+      <button class="btn btn-primary" id="btn-confirm-new-project">Create</button>
+      <button class="btn btn-ghost modal-close">Cancel</button>
+    </div>
+  </div>
+</template>
+
+<script type="module">
+import { bus        } from './core/bus.js';
+import { store      } from './core/store.js';
+import { gateway    } from './core/gateway.js';
+import { governance } from './core/governance.js';
+
+// Service worker
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('./core/worker.js').catch(() => {});
+}
+
+await store.ready;
+await governance.init();
+gateway.setPolicy(governance);
+
+// Register routes
+gateway.register('projects.list',   () => store.getAll('projects'));
+gateway.register('projects.create', (p) => store.set('projects', p.id ?? crypto.randomUUID(), p));
+gateway.register('tasks.list',      (p) => store.query('tasks', t => t.projectId === p.projectId));
+
+// Auth integration — check session with Javelin Flask backend
+async function checkAuth() {
+  try {
+    const res  = await fetch('/api/hello');
+    if (res.ok) {
+      const data = await res.json();
+      setUser(data.user ?? 'authenticated');
+    }
+  } catch {
+    setUser('local');
+  }
+}
+
+function setUser(name) {
+  document.getElementById('user-display').textContent  = name;
+  document.getElementById('footer-user').textContent   = name;
+  document.getElementById('stat-user').textContent     = name;
+  bus.emit('auth:user_set', { user: name });
+}
+
+// Navigation
+function showPanel(name) {
+  document.querySelectorAll('.nexus-panel').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('[data-panel]').forEach(b => {
+    b.classList.toggle('active', b.dataset.panel === name);
+  });
+  const panel = document.getElementById(`panel-${name}`);
+  if (panel) panel.classList.add('active');
+  bus.emit('ui:panel_change', { panel: name });
+}
+
+document.querySelectorAll('[data-panel]').forEach(el =>
+  el.addEventListener('click', () => showPanel(el.dataset.panel))
+);
+
+// Toast
+function toast(msg, type = 'info', dur = 3500) {
+  const c  = document.getElementById('toast-container');
+  const t  = document.createElement('div');
+  t.className = `toast ${type}`;
+  t.innerHTML = `<span>${msg}</span><button class="btn btn-ghost btn-sm btn-icon" onclick="this.closest('.toast').remove()" style="margin-left:auto;">✕</button>`;
+  c.appendChild(t);
+  setTimeout(() => t.remove(), dur);
+}
+window.toast = toast;
+
+// Projects
+async function renderProjects() {
+  const projects = await gateway.call('projects.list');
+  const badge    = document.getElementById('badge-projects');
+  const countLbl = document.getElementById('projects-count-label');
+  if (badge)    badge.textContent  = projects.length;
+  if (countLbl) countLbl.textContent = `${projects.length} projects`;
+  document.getElementById('stat-projects').textContent = projects.filter(p => p.status === 'active').length;
+}
+
+// Activity
+function addActivity(msg, color = 'cyan') {
+  ['activity-feed', 'sidebar-activity'].forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    if (el.querySelector('.empty-state')) el.innerHTML = '';
+    el.insertAdjacentHTML('afterbegin', `
+      <div class="activity-item">
+        <div class="activity-dot ${color}"></div>
+        <div class="activity-content">
+          <div>${msg}</div>
+          <div class="activity-time">${new Date().toLocaleTimeString()}</div>
+        </div>
+      </div>`);
+  });
+}
+
+bus.on('projects:created', (p) => addActivity(`Project: ${p.name}`, 'cyan'));
+bus.on('auth:user_set',    (e) => addActivity(`Logged in as ${e.user}`, 'green'));
+
+// Governance panel
+async function initGovernance() {
+  const policy = governance.getPolicy();
+  const editor = document.getElementById('policy-editor');
+  if (editor) editor.value = JSON.stringify(policy, null, 2);
+
+  bus.on('governance:audit', (e) => {
+    const log  = document.getElementById('audit-log');
+    if (!log) return;
+    const line = document.createElement('div');
+    line.className = `log-line ${e.allowed ? 'success' : 'warn'}`;
+    line.textContent = `[${new Date(e.ts).toLocaleTimeString()}] ${e.allowed ? 'ALLOW' : 'DENY'} ${e.route}`;
+    log.insertBefore(line, log.firstChild);
+  });
+
+  document.getElementById('btn-save-policy')?.addEventListener('click', async () => {
+    try { await governance.setPolicy(JSON.parse(editor.value)); toast('Policy saved', 'success'); }
+    catch { toast('Invalid JSON', 'error'); }
+  });
+}
+
+// Connectivity
+function updateConnectivity() {
+  const online = navigator.onLine;
+  document.getElementById('status-connectivity')?.classList.toggle('online', online);
+  document.getElementById('status-connectivity')?.classList.toggle('warning', !online);
+  document.getElementById('status-label').textContent        = online ? 'Online' : 'Offline';
+  document.getElementById('offline-banner').style.display    = online ? 'none' : 'flex';
+  document.getElementById('footer-status-dot')?.classList.toggle('online', online);
+}
+
+window.addEventListener('online',  updateConnectivity);
+window.addEventListener('offline', updateConnectivity);
+updateConnectivity();
+
+// Clock
+setInterval(() => {
+  const el = document.getElementById('footer-time');
+  if (el) el.textContent = new Date().toLocaleTimeString();
+}, 1000);
+
+// Logout
+document.getElementById('btn-logout')?.addEventListener('click', async () => {
+  try { await fetch('/logout', { method: 'POST' }); } catch {}
+  window.location.href = '/';
+});
+
+// Boot
+await checkAuth();
+await renderProjects();
+await initGovernance();
+
+bus.emit('system:ready', { app: 'javelin', ts: Date.now() });
+addActivity('Javelin Nexus ready', 'green');
+document.body.classList.add('nexus-ready');
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Adds nexus/ subdirectory to javelin — mirrors the workstation nexus architecture with javelin-specific adaptations:

  • nexus.html — Javelin-branded SPA with Containers panel showing
    DeckBoss, ZSkipper, DataFarm, Captain, Maps, OpenContainer cards
  • nexus.css — shared pastel design system (cyan/yellow/silgreen/shale)
  • core/ — shared EventBus, LocalStore, APIGateway, GovernanceEngine,
    Service Worker (identical to workstation)
  • integrations/ — Airtable, AI/Claude, GitHub, Portals stubs
  • backend/api/javelin_nexus.py — Flask Blueprint extending existing
    Javelin auth with /api/nexus/* routes, container lifecycle management,
    SSE log streaming, SavedPoint integration, webhook receiver
  • docs/ — Architecture, Governance, Integration Guide documentation

Register in existing Flask app:
    from nexus.backend.api.javelin_nexus import nexus_bp
    app.register_blueprint(nexus_bp)

https://claude.ai/code/session_013V8JDaGnQogNbqudTPBcLm